### PR TITLE
Replace values

### DIFF
--- a/src/main/resources/ome/services/blitz-servantDefinitions.xml
+++ b/src/main/resources/ome/services/blitz-servantDefinitions.xml
@@ -311,7 +311,7 @@
   ==============================================================================
   -->
 
-  <bean id="::omero::cmd::Handle" class="omero.cmd._HandleTie" scope="prototype">
+  <bean id="omero_cmd_Handle" class="omero.cmd._HandleTie" scope="prototype">
     <constructor-arg>
         <bean class="omero.cmd.HandleI" scope="prototype">
             <constructor-arg ref="readOnlyStatus"/>


### PR DESCRIPTION
replace ``::`` by`` _``
Injecting perf4j at runtime leads to a SAX parsing error if we use ``::``

For testing, use https://github.com/jburel/omero-build/tree/bugfixes 