### PR TITLE
Deprecate graph util methods expected to be removed.

### DIFF
--- a/src/main/java/omero/cmd/graphs/GraphUtil.java
+++ b/src/main/java/omero/cmd/graphs/GraphUtil.java
@@ -117,7 +117,9 @@ public class GraphUtil {
      * @param session the Hibernate session
      * @param targetObjects the objects that are to be deleted
      * @return the given target objects with any original files suitably ordered for deletion
+     * @deprecated in anticipation of refactoring
      */
+    @Deprecated
     static SetMultimap<String, Long> arrangeDeletionTargets(Session session, SetMultimap<String, Long> targetObjects) {
         if (targetObjects.get(OriginalFile.class.getName()).size() < 2) {
             /* no need to rearrange anything, as there are not multiple original files */

--- a/src/test/java/omero/cmd/graphs/GraphUtilTest.java
+++ b/src/test/java/omero/cmd/graphs/GraphUtilTest.java
@@ -63,6 +63,7 @@ public class GraphUtilTest {
      * Generate test data for {@link #testGetFirstClassName(String, String)}.
      * @return pairs of type paths and the first class name from each path
      */
+    @Deprecated
     @DataProvider(name = "type paths")
     public String[][] getTypePaths() {
         return new String[][] {


### PR DESCRIPTION
Deprecating some graph utility methods that probably nobody will miss and that are not expected to be needed by 5.5.1 at the latest.