### PR TITLE
Java Gateway improvements

### DIFF
--- a/src/main/java/omero/gateway/facility/DataManagerFacility.java
+++ b/src/main/java/omero/gateway/facility/DataManagerFacility.java
@@ -36,9 +36,9 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
 
 import omero.ServerError;
 import omero.api.IContainerPrx;
@@ -54,6 +54,7 @@ import omero.gateway.exception.DSOutOfServiceException;
 import omero.gateway.model.DataObject;
 import omero.gateway.model.DatasetData;
 import omero.gateway.model.ImageData;
+import omero.gateway.util.Links;
 import omero.gateway.util.PojoMapper;
 import omero.gateway.util.Pojos;
 import omero.gateway.util.Requests;
@@ -83,6 +84,7 @@ import omero.model.WellAnnotationLink;
 import omero.model.WellAnnotationLinkI;
 import omero.model.enums.ChecksumAlgorithmSHA1160;
 import omero.sys.Parameters;
+import omero.sys.ParametersI;
 import omero.gateway.model.AnnotationData;
 import omero.gateway.model.FileAnnotationData;
 import omero.gateway.model.FolderData;
@@ -808,4 +810,54 @@ public class DataManagerFacility extends Facility {
         return null;
     }
     
+    /**
+     * Moves DataObjects from one object to another, i.e. Annotations from one
+     * Image to another, or Images from one Dataset to another.
+     * 
+     * @param ctx
+     *            The SecurityContext
+     * @param objects
+     *            The objects to move
+     * @param from
+     *            The object to which the objects are attached now
+     * @param to
+     *            The object to which the objects should be attached to
+     * @throws DSOutOfServiceException
+     * @throws DSAccessException
+     */
+    public void move(SecurityContext ctx, List<? extends DataObject> objects,
+            DataObject from, DataObject to)
+            throws DSOutOfServiceException, DSAccessException {
+        try {
+            if (!from.getClass().equals(to.getClass()))
+                throw new IllegalArgumentException(
+                        "Source and target object need to be the same type!");
+
+            if (objects.isEmpty())
+                return;
+
+            Class<? extends IObject> type = Links.getLinkClass(from.getClass(),
+                    objects.get(0).getClass());
+            if (type == null)
+                throw new IllegalArgumentException(
+                        "Can't determine the link type for this class");
+
+            String query = "select link from "
+                    + PojoMapper.getHQLEntityName(type)
+                    + " link join fetch link.child as c join fetch link.parent as p where c.id in (:ids) and p.id = :parentId";
+            ParametersI params = new ParametersI();
+            Collection<Long> ids = objects.stream().map(obj -> obj.getId())
+                    .collect(Collectors.toList());
+            params.addIds(ids);
+            params.add("parentId", omero.rtypes.rlong(from.getId()));
+
+            List<IObject> links = gateway.getQueryService(ctx)
+                    .findAllByQuery(query, params);
+            for (IObject link : links)
+                Links.setObjects(link, to, null);
+            updateObjects(ctx, links, null);
+        } catch (Throwable t) {
+            handleException(this, t, "Cannot move the annotation.");
+        }
+    }
 }

--- a/src/main/java/omero/gateway/facility/DataManagerFacility.java
+++ b/src/main/java/omero/gateway/facility/DataManagerFacility.java
@@ -821,7 +821,7 @@ public class DataManagerFacility extends Facility {
      * @param from
      *            The object to which the objects are attached now
      * @param to
-     *            The object to which the objects should be attached to
+     *            The object to which the objects should be attached
      * @throws DSOutOfServiceException
      * @throws DSAccessException
      */
@@ -829,7 +829,7 @@ public class DataManagerFacility extends Facility {
             DataObject from, DataObject to)
             throws DSOutOfServiceException, DSAccessException {
         try {
-            if (!from.getClass().equals(to.getClass()))
+            if (from.getClass() != to.getClass())
                 throw new IllegalArgumentException(
                         "Source and target object need to be the same type!");
 

--- a/src/main/java/omero/gateway/model/MaskData.java
+++ b/src/main/java/omero/gateway/model/MaskData.java
@@ -439,9 +439,9 @@ public class MaskData
         // purposes (only for small masks)
         StringBuilder sb = new StringBuilder();
         int[][] bin = getMaskAsBinaryArray();
-        for (int i=0; i<bin.length; i++) {
-            for (int j=0; j<bin[0].length; j++) {
-                if (bin[i][j] > 0)
+        for (int i=0; i<bin[0].length; i++) {
+            for (int j=0; j<bin.length; j++) {
+                if (bin[j][i] > 0)
                     sb.append('1');
                 else
                     sb.append('0');

--- a/src/main/java/omero/gateway/model/PixelsData.java
+++ b/src/main/java/omero/gateway/model/PixelsData.java
@@ -244,7 +244,10 @@ public class PixelsData extends DataObject {
 
     /**
      * Returns the dimension of a pixel along the X-axis.
-     *
+     * 
+     * Note: Do not use the returned Length object to modify the
+     * pixel size, use the setPixelSizeX method instead.
+     * 
      * @param unit
      *            The unit (may be null, in which case no conversion will be
      *            performed)
@@ -272,6 +275,9 @@ public class PixelsData extends DataObject {
     /**
      * Returns the dimension of a pixel along the Y-axis.
      *
+     * Note: Do not use the returned Length object to modify the
+     * pixel size, use the setPixelSizeY method instead.
+     * 
      * @param unit
      *            The unit (may be null, in which case no conversion will be
      *            performed)
@@ -299,6 +305,9 @@ public class PixelsData extends DataObject {
     /**
      * Returns the dimension of a pixel along the Z-axis
      *
+     * Note: Do not use the returned Length object to modify the
+     * pixel size, use the setPixelSizeZ method instead.
+     * 
      * @param unit
      *            The unit (may be null, in which case no conversion will be
      *            performed)

--- a/src/main/java/omero/gateway/model/ROIData.java
+++ b/src/main/java/omero/gateway/model/ROIData.java
@@ -1,6 +1,6 @@
 /*
  *------------------------------------------------------------------------------
- * Copyright (C) 2006-2018 University of Dundee. All rights reserved.
+ * Copyright (C) 2006-2019 University of Dundee. All rights reserved.
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -243,7 +243,18 @@ public class ROIData
     }
 
     /**
-     * Returns the list of shapes on a given plane.
+     * Returns a list of all shapes.
+     * 
+     * @return See above.
+     */
+    public List<ShapeData> getShapes() {
+        List<ShapeData> res = new ArrayList<ShapeData>();
+        roiShapes.values().stream().forEach(list -> res.addAll(list));
+        return res;
+    }
+
+    /**
+     * Returns a list of shapes on a given plane.
      *
      * @param z The z-section.
      * @param t The timepoint.

--- a/src/main/java/omero/gateway/model/ROIData.java
+++ b/src/main/java/omero/gateway/model/ROIData.java
@@ -256,24 +256,31 @@ public class ROIData
     /**
      * Returns a list of shapes on a given plane.
      *
-     * @param z The z-section.
-     * @param t The timepoint.
+     * @param z
+     *            The z-section.
+     * @param t
+     *            The timepoint.
      * @return See above.
      */
-    public List<ShapeData> getShapes(int z, int t)
-    {
+    public List<ShapeData> getShapes(int z, int t) {
         List<ShapeData> res = roiShapes.get(new ROICoordinate(z, t));
         if (res == null)
             res = new ArrayList<ShapeData>();
-        List<ShapeData> allZT = roiShapes.get(new ROICoordinate(-1, -1));
-        if (allZT != null)
-            res.addAll(allZT);
-        List<ShapeData> allZ = roiShapes.get(new ROICoordinate(-1, t));
-        if (allZ != null)
-            res.addAll(allZ);
-        List<ShapeData> allT = roiShapes.get(new ROICoordinate(z, -1));
-        if (allT != null)
-            res.addAll(allT);
+        if (z != -1 || t != -1) {
+            List<ShapeData> allZT = roiShapes.get(new ROICoordinate(-1, -1));
+            if (allZT != null)
+                res.addAll(allZT);
+        }
+        if (z != -1) {
+            List<ShapeData> allZ = roiShapes.get(new ROICoordinate(-1, t));
+            if (allZ != null)
+                res.addAll(allZ);
+        }
+        if (t != -1) {
+            List<ShapeData> allT = roiShapes.get(new ROICoordinate(z, -1));
+            if (allT != null)
+                res.addAll(allT);
+        }
         return res;
     }
 

--- a/src/main/java/omero/gateway/util/Links.java
+++ b/src/main/java/omero/gateway/util/Links.java
@@ -1,0 +1,97 @@
+package omero.gateway.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import omero.gateway.model.DataObject;
+import omero.model.IObject;
+
+/**
+ * Some helper methods dealing with XXXYYYLinkI IObjects, e.g.
+ * ImageAnnotationLinkI
+ * 
+ * @author Dominik Lindner &nbsp;&nbsp;&nbsp;&nbsp;
+ *         <a href="mailto:d.lindner@dundee.ac.uk">d.lindner@dundee.ac.uk</a>
+ *
+ */
+public class Links {
+
+    /**
+     * Get the Link class for a certain child parent combination, e.g. parent:
+     * DatasetData, child: ImageData => omero.model.DatasetImageLinkI
+     * 
+     * @param parent
+     *            The parent
+     * @param child
+     *            The child
+     * @return See above
+     * @throws ClassNotFoundException
+     */
+    public static Class<? extends IObject> getLinkClass(
+            Class<? extends DataObject> parent,
+            Class<? extends DataObject> child) throws ClassNotFoundException {
+        String parentType = getType(parent);
+        String childType = getType(child);
+        String type = parentType + childType + "LinkI";
+        return (Class<? extends IObject>) Class.forName("omero.model." + type);
+    }
+
+    /**
+     * Set the parent, child or both of an existing link
+     * 
+     * @param link
+     *            The link object
+     * @param parent
+     *            The parent (or <code>null</code>)
+     * @param child
+     *            The child (or <code>null</code>)
+     * @return The link object
+     * @throws ClassNotFoundException
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
+     * @throws InvocationTargetException
+     */
+    public static IObject setObjects(IObject link, DataObject parent,
+            DataObject child) throws ClassNotFoundException,
+            NoSuchMethodException, SecurityException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException {
+        Class<? extends IObject> clazz = link.getClass();
+        if (parent != null) {
+            for (Method m : clazz.getSuperclass().getMethods()) {
+                if (m.getName().equals("setParent")) {
+                    m.invoke(link,
+                            m.getParameterTypes()[0].cast(parent.asIObject()));
+                    break;
+                }
+            }
+        }
+        if (child != null) {
+            for (Method m : clazz.getSuperclass().getMethods()) {
+                if (m.getName().equals("setChild")) {
+                    m.invoke(link,
+                            m.getParameterTypes()[0].cast(child.asIObject()));
+                    break;
+                }
+            }
+        }
+        return link;
+    }
+
+    /**
+     * Get the IObject type of DataObject class with respect to links
+     * 
+     * @param clazz
+     *            The DataObject class
+     * @return See above
+     */
+    private static String getType(Class<? extends DataObject> clazz) {
+        String type = clazz.getSimpleName();
+        if (type.endsWith("Data"))
+            type = type.substring(0, type.length() - 4);
+        if (type.contains("Annotation"))
+            type = "Annotation";
+        return type;
+    }
+}

--- a/src/main/java/omero/gateway/util/Links.java
+++ b/src/main/java/omero/gateway/util/Links.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright (C) 2019 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 package omero.gateway.util;
 
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 import omero.gateway.model.DataObject;
 import omero.model.IObject;
+import org.apache.commons.beanutils.PropertyUtils;
 
 /**
  * Some helper methods dealing with XXXYYYLinkI IObjects, e.g.
@@ -38,15 +56,11 @@ public class Links {
 
     /**
      * Set the parent, child or both of an existing link
-     * 
-     * @param link
-     *            The link object
-     * @param parent
-     *            The parent (or <code>null</code>)
-     * @param child
-     *            The child (or <code>null</code>)
+     *
+     * @param link   The link object
+     * @param parent The parent (or <code>null</code>)
+     * @param child  The child (or <code>null</code>)
      * @return The link object
-     * @throws ClassNotFoundException
      * @throws NoSuchMethodException
      * @throws SecurityException
      * @throws IllegalAccessException
@@ -54,27 +68,14 @@ public class Links {
      * @throws InvocationTargetException
      */
     public static IObject setObjects(IObject link, DataObject parent,
-            DataObject child) throws ClassNotFoundException,
+                                     DataObject child) throws
             NoSuchMethodException, SecurityException, IllegalAccessException,
             IllegalArgumentException, InvocationTargetException {
-        Class<? extends IObject> clazz = link.getClass();
         if (parent != null) {
-            for (Method m : clazz.getSuperclass().getMethods()) {
-                if (m.getName().equals("setParent")) {
-                    m.invoke(link,
-                            m.getParameterTypes()[0].cast(parent.asIObject()));
-                    break;
-                }
-            }
+            PropertyUtils.setProperty(link, "parent", parent.asIObject());
         }
         if (child != null) {
-            for (Method m : clazz.getSuperclass().getMethods()) {
-                if (m.getName().equals("setChild")) {
-                    m.invoke(link,
-                            m.getParameterTypes()[0].cast(child.asIObject()));
-                    break;
-                }
-            }
+            PropertyUtils.setProperty(link, "child", child.asIObject());
         }
         return link;
     }

--- a/src/main/java/omero/gateway/util/Mask.java
+++ b/src/main/java/omero/gateway/util/Mask.java
@@ -92,7 +92,7 @@ public class Mask {
         {
             for (int x = 0 ; x < neww ; x++)
             {
-                newmask[x][y] = mask[x+minx][y+miny];
+                newmask[x][y] = mask[x+minx][maxy-y];
             }
         }
         
@@ -137,6 +137,19 @@ public class Mask {
     }
 
     /**
+     * Creates mask ROIs from the given integer array where each 
+     * single mask ROI is specified by a specific integer.
+     * 
+     * @param masks The masks covering the whole image.
+     * @param width The width of the image
+     * @return The mask ROIs
+     */
+    public static List<MaskData> createCroppedMasks(int[] masks, int width) {
+        int[][] folded = fold(masks, width);
+        return createCroppedMasks(folded);
+    }
+    
+    /**
      * Simply iterates over the array and returns the first non zero integer
      * found.
      * 
@@ -168,4 +181,60 @@ public class Mask {
         return result;
     }
     
+    /**
+     * Breaks a one-dimensional array into 'length' chunks,
+     * forming a two-dimensional array, e.g.
+     * 
+     * int[] x = 0 1 2 3 4 5 6 7 8 9 
+     * 
+     * using length = 4 will be transformed to
+     * 
+     * int[][] y = 
+     * [0 1 2 3]
+     * [4 5 6 7]
+     * [8 9 0 0]
+     * 
+     * @param array An int array
+     * @param length The length of the chunks
+     * @return Two dimensional array
+     */
+    public static int[][] fold(int[] array, int length) {
+        int height = array.length / length;
+        if ( array.length % length != 0) 
+            height++;
+        int[][] result = new int[height][length];
+        for (int i = 0; i < array.length; i++)
+            result[i / length][i % length] = array[i];
+        return result;
+    }
+    
+    /**
+     * Transforms a 2 dimensional array into a one dimensional
+     * array; the opposite of the fold method.
+     * 
+     * E. g. 
+     * int[][] y = 
+     * [0 1 2 3]
+     * [4 5 6 7]
+     * [8 9 0 0]
+     * 
+     * would transformed into
+     * 
+     * int[] x = 0 1 2 3 4 5 6 7 8 9 0 0
+     * 
+     * @param array An int array
+     * @return The one dimensional array
+     */
+    public static int[] unfold(int[][] array) {
+        
+        int w = array.length;
+        int h = array[0].length;
+        
+        int[] result = new int[w*h];
+        
+        for (int i = 0; i < w; i++)
+            for (int j = 0; j < h; j++)
+                result[i * h + j] = array[i][j];
+        return result;
+    }
 }

--- a/src/main/java/omero/gateway/util/Mask.java
+++ b/src/main/java/omero/gateway/util/Mask.java
@@ -184,7 +184,7 @@ public class Mask {
     /**
      * Breaks a one-dimensional array into 'length' chunks,
      * forming a two-dimensional array, e.g.
-     * 
+     * <pre>
      * int[] x = 0 1 2 3 4 5 6 7 8 9 
      * 
      * using length = 4 will be transformed to
@@ -193,7 +193,7 @@ public class Mask {
      * [0 1 2 3]
      * [4 5 6 7]
      * [8 9 0 0]
-     * 
+     * </pre>
      * @param array An int array
      * @param length The length of the chunks
      * @return Two dimensional array
@@ -211,7 +211,7 @@ public class Mask {
     /**
      * Transforms a 2 dimensional array into a one dimensional
      * array; the opposite of the fold method.
-     * 
+     * <pre>
      * E. g. 
      * int[][] y = 
      * [0 1 2 3]
@@ -221,7 +221,7 @@ public class Mask {
      * would transformed into
      * 
      * int[] x = 0 1 2 3 4 5 6 7 8 9 0 0
-     * 
+     * </pre>
      * @param array An int array
      * @return The one dimensional array
      */

--- a/src/main/java/omero/gateway/util/PojoMapper.java
+++ b/src/main/java/omero/gateway/util/PojoMapper.java
@@ -42,6 +42,7 @@ import omero.model.BooleanAnnotationI;
 import omero.model.CommentAnnotation;
 import omero.model.CommentAnnotationI;
 import omero.model.Dataset;
+import omero.model.DatasetAnnotationLinkI;
 import omero.model.DatasetI;
 import omero.model.DoubleAnnotation;
 import omero.model.Ellipse;
@@ -53,6 +54,7 @@ import omero.model.Fileset;
 import omero.model.Folder;
 import omero.model.IObject;
 import omero.model.Image;
+import omero.model.ImageAnnotationLinkI;
 import omero.model.ImageI;
 import omero.model.Label;
 import omero.model.Line;
@@ -65,15 +67,18 @@ import omero.model.Pixels;
 import omero.model.Plate;
 import omero.model.PlateAcquisition;
 import omero.model.PlateAcquisitionI;
+import omero.model.PlateAnnotationLinkI;
 import omero.model.PlateI;
 import omero.model.Point;
 import omero.model.Polygon;
 import omero.model.Polyline;
 import omero.model.Project;
+import omero.model.ProjectAnnotationLinkI;
 import omero.model.ProjectI;
 import omero.model.Rectangle;
 import omero.model.Roi;
 import omero.model.Screen;
+import omero.model.ScreenAnnotationLinkI;
 import omero.model.ScreenI;
 import omero.model.TagAnnotation;
 import omero.model.TagAnnotationI;
@@ -82,6 +87,7 @@ import omero.model.TermAnnotationI;
 import omero.model.TimestampAnnotation;
 import omero.model.TimestampAnnotationI;
 import omero.model.Well;
+import omero.model.WellAnnotationLinkI;
 import omero.model.WellI;
 import omero.model.WellSample;
 import omero.model.XmlAnnotation;
@@ -676,5 +682,21 @@ public class PojoMapper
                 nodeType.equals(PlateAcquisitionData.class))
             return PlateAcquisitionI.class.getName();
         throw new IllegalArgumentException("type not supported");
+    }
+
+    /**
+     * Gets the type of an IObject class as String which can be used in HQL
+     * queries.
+     * 
+     * @param clazz
+     *            The IObject
+     * @return See above
+     */
+    public static String getHQLEntityName(Class<? extends IObject> clazz) {
+        String name = clazz.getSimpleName();
+        if (name.endsWith("I"))
+            return name.substring(0, name.length() - 1);
+        else
+            return name;
     }
 }


### PR DESCRIPTION
This PR adds some improvements to the Java gateway:

- Adds a `move` method to the DataManagerFacility, which can be used to move objects from one parent to another (e.g. annotations from one image to another or images from one dataset to another).
- Fixes some issues with mask utilitiy methods.
- Add a methods to simply get all shapes (ie ROIs) of an image.
- Fixes an issue with the `getShapes(int z, int t)` method (it was possible that the returned list contained the same shapes multiple times).
- Adds a warning to the `getPixelSize` methods to not use the returned objects to set the pixel size, but use the `setPixelSize` methods instead.
