### PR TITLE
Deprecate setCaseSentivice in favor of new setCaseSensitive.

### DIFF
--- a/src/main/java/ome/services/blitz/impl/SearchI.java
+++ b/src/main/java/ome/services/blitz/impl/SearchI.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -57,6 +55,7 @@ import omero.api.AMD_Search_resetDefaults;
 import omero.api.AMD_Search_results;
 import omero.api.AMD_Search_setAllowLeadingWildcard;
 import omero.api.AMD_Search_setBatchSize;
+import omero.api.AMD_Search_setCaseSensitive;
 import omero.api.AMD_Search_setCaseSentivice;
 import omero.api.AMD_Search_setMergedBatches;
 import omero.api.AMD_Search_setReturnUnloaded;
@@ -355,6 +354,12 @@ public class SearchI extends AbstractCloseableAmdServant implements _SearchOpera
     }
 
     public void setCaseSentivice_async(AMD_Search_setCaseSentivice __cb,
+            boolean caseSensitive, Current __current) throws ServerError {
+        callInvokerOnRawArgs(__cb, __current, caseSensitive);
+
+    }
+
+    public void setCaseSensitive_async(AMD_Search_setCaseSensitive __cb,
             boolean caseSensitive, Current __current) throws ServerError {
         callInvokerOnRawArgs(__cb, __current, caseSensitive);
 

--- a/src/main/java/omero/gateway/facility/SearchFacility.java
+++ b/src/main/java/omero/gateway/facility/SearchFacility.java
@@ -112,7 +112,7 @@ public class SearchFacility extends Facility {
                 // set general parameters
                 service.clearQueries();
                 service.setAllowLeadingWildcard(true);
-                service.setCaseSentivice(false);
+                service.setCaseSensitive(false);
                 String searchForClass = PojoMapper.convertTypeForSearch(type);
                 service.onlyType(searchForClass);
                 service.setBatchSize(batchSize);

--- a/src/main/slice/omero/api/Search.ice
+++ b/src/main/slice/omero/api/Search.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -26,7 +24,7 @@ module omero {
          *
          * Each instance also has a number of settings which can all be
          * changed from their defaults via accessors, e.g.
-         * {@link #setBatchSize} or {@link #setCaseSentivice}.
+         * {@link #setBatchSize} or {@link #setCaseSensitive}.
          *
          * The only methods which are required for the proper functioning of a
          * {@link Search} instance are:
@@ -99,11 +97,18 @@ module omero {
                  * Sets the case sensitivity on all queries where
                  * case-sensitivity is supported.
                  */
+                ["deprecate:use setCaseSensitive instead"]
                 idempotent void setCaseSentivice(bool caseSensitive) throws ServerError;
 
                 /**
+                 * Sets the case sensitivity on all queries where
+                 * case-sensitivity is supported.
+                 */
+                idempotent void setCaseSensitive(bool caseSensitive) throws ServerError;
+
+                /**
                  * Returns the current case sensitivity setting. If
-                 * {@link #setCaseSentivice} has not been called, the
+                 * {@link #setCaseSensitive} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isCaseSensitive() throws ServerError;


### PR DESCRIPTION
The Search API has a `setCaseSentivice` which is deprecated in favor of a new `setCaseSensitive` method.

Requires https://github.com/ome/omero-common/pull/9 and https://github.com/ome/omero-server/pull/12.