### PR TITLE
deprecate vestigial data provider for deleted test

### DIFF
--- a/src/test/java/omero/cmd/graphs/GraphUtilTest.java
+++ b/src/test/java/omero/cmd/graphs/GraphUtilTest.java
@@ -62,7 +62,9 @@ public class GraphUtilTest {
     /**
      * Generate test data for {@link #testGetFirstClassName(String, String)}.
      * @return pairs of type paths and the first class name from each path
+     * @deprecated no longer used
      */
+    @Deprecated
     @DataProvider(name = "type paths")
     public String[][] getTypePaths() {
         return new String[][] {


### PR DESCRIPTION
I suspect that `testGetFirstClassName` is long-gone. Its test data provider should follow.