### PR TITLE
add DEBUG logging for successful repository file deletions

### DIFF
--- a/src/main/java/ome/services/blitz/repo/AbstractRepositoryI.java
+++ b/src/main/java/ome/services/blitz/repo/AbstractRepositoryI.java
@@ -172,7 +172,9 @@ public abstract class AbstractRepositoryI extends _InternalRepositoryDisp
                 }
                 try {
                     final CheckedPath checked = servant.checkPath(filename, null, null /* i.e. as admin*/);
-                    if (!checked.delete()) {
+                    if (checked.delete()) {
+                        log.debug("DELETED: {}", checked);
+                    } else {
                         Throwable t = new omero.grid.FileDeleteException(
                                 null, null, "Delete file failed: " + filename);
                         dlm.error(dl, t);


### PR DESCRIPTION
Most server file deletions are logged at debug level but this appears to be an exception. To test, try deleting some images after first including in `etc/logback.xml`,
```xml
<logger name="ome.services.blitz.repo.AbstractRepositoryI" level="DEBUG"/>
```