### PR TITLE
safely order repository file deletions

### DIFF
--- a/src/main/java/omero/cmd/graphs/Chgrp2I.java
+++ b/src/main/java/omero/cmd/graphs/Chgrp2I.java
@@ -36,7 +36,6 @@ import org.springframework.context.ApplicationContext;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.model.IObject;
@@ -187,9 +186,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, ReadOnlyStatus.IsAware,
             case 0:
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
-                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(targetMultimap, true, true);
-                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
+                return graphTraversal.planOperation(targetMultimap, true, true);
             case 1:
                 graphTraversal.assertNoPolicyViolations();
                 return null;

--- a/src/main/java/omero/cmd/graphs/Chmod2I.java
+++ b/src/main/java/omero/cmd/graphs/Chmod2I.java
@@ -37,7 +37,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.api.IAdmin;
@@ -182,12 +181,11 @@ public class Chmod2I extends Chmod2 implements IRequest, ReadOnlyStatus.IsAware,
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
                 /* only downgrade to private requires the graph policy rules to be applied */
-                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan;
                 final Permissions newPermissions = Utils.toPermissions(perm1);
                 final boolean isToGroupReadable = newPermissions.isGranted(Permissions.Role.GROUP, Permissions.Right.READ);
                 if (isToGroupReadable) {
                     /* can always skip graph policy rules as is not downgrade to private */
-                    plan = graphTraversal.planOperation(targetMultimap, true, false);
+                    return graphTraversal.planOperation(targetMultimap, true, false);
                 } else {
                     /* determine which target groups are not already private ... */
                     final String groupClass = ExperimenterGroup.class.getName();
@@ -211,9 +209,8 @@ public class Chmod2I extends Chmod2 implements IRequest, ReadOnlyStatus.IsAware,
                         }
                     }
                     /* ... and apply the graph policy rules to those */
-                    plan = graphTraversal.planOperation(targetsNotPrivate, true, true);
+                    return graphTraversal.planOperation(targetsNotPrivate, true, true);
                 }
-                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
             case 1:
                 graphTraversal.assertNoPolicyViolations();
                 return null;

--- a/src/main/java/omero/cmd/graphs/Chown2I.java
+++ b/src/main/java/omero/cmd/graphs/Chown2I.java
@@ -41,7 +41,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.api.IAdmin;
@@ -310,9 +309,7 @@ public class Chown2I extends Chown2 implements IRequest, ReadOnlyStatus.IsAware,
             case 1:
                 final SetMultimap<String, Long> targetMultimap = graphHelper.getTargetMultimap(targetClasses, targetObjects);
                 targetObjectCount += targetMultimap.size();
-                final Entry<SetMultimap<String, Long>, SetMultimap<String, Long>> plan =
-                        graphTraversal.planOperation(targetMultimap, true, true);
-                return Maps.immutableEntry(plan.getKey(), GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue()));
+                return graphTraversal.planOperation(targetMultimap, true, true);
             case 2:
                 graphTraversal.assertNoPolicyViolations();
                 return null;

--- a/src/main/java/omero/cmd/graphs/Delete2I.java
+++ b/src/main/java/omero/cmd/graphs/Delete2I.java
@@ -153,7 +153,7 @@ public class Delete2I extends Delete2 implements IRequest, ReadOnlyStatus.IsAwar
                     final Exception e = new IllegalStateException("deletion does not do anything other than delete");
                     helper.cancel(new ERR(), e, "graph-fail");
                 }
-                return GraphUtil.arrangeDeletionTargets(helper.getSession(), plan.getValue());
+                return plan.getValue();
             case 1:
                 graphTraversal.assertNoPolicyViolations();
                 return null;

--- a/src/main/java/omero/cmd/graphs/GraphUtil.java
+++ b/src/main/java/omero/cmd/graphs/GraphUtil.java
@@ -117,7 +117,9 @@ public class GraphUtil {
      * @param session the Hibernate session
      * @param targetObjects the objects that are to be deleted
      * @return the given target objects with any original files suitably ordered for deletion
+     * @deprecated no longer used internally, replaced by {@code GraphTraversal.orderFileDeletion()}
      */
+    @Deprecated
     static SetMultimap<String, Long> arrangeDeletionTargets(Session session, SetMultimap<String, Long> targetObjects) {
         if (targetObjects.get(OriginalFile.class.getName()).size() < 2) {
             /* no need to rearrange anything, as there are not multiple original files */


### PR DESCRIPTION
To test, try deleting whole directory structures, directories *and* file contents, and the image objects whose files they represent, all in the same `Delete2` request. One way to do this would be to revert https://github.com/openmicroscopy/management_tools/commit/4eae148467667b711f48341e378e267b705f7329 out of the `delete-user-data.py` demo user deletion script and to really delete real user data (*not* a dry run so on a test system!). Without this fix the deletion will fail.