### PR TITLE
adjust some Blitz API responses to signal "OK"

### DIFF
--- a/src/main/slice/omero/Repositories.ice
+++ b/src/main/slice/omero/Repositories.ice
@@ -1,9 +1,6 @@
 /*
-*   $Id$
-*
 *   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
 *   Use is subject to license terms supplied in LICENSE.txt
-*
 */
 
 #ifndef OMERO_REPOSITORY_ICE

--- a/src/main/slice/omero/Repositories.ice
+++ b/src/main/slice/omero/Repositories.ice
@@ -429,7 +429,7 @@ module omero {
          * to return the results, but is likely not the
          * overall best strategy.
          **/
-        class ImportResponse extends ::omero::cmd::Response {
+        class ImportResponse extends omero::cmd::OK {
 
             omero::api::PixelsList pixels;
 

--- a/src/main/slice/omero/cmd/Admin.ice
+++ b/src/main/slice/omero/cmd/Admin.ice
@@ -36,7 +36,7 @@ module omero {
           * If no valid user with matching email is found,
           * an {@link ERR} will be returned.
           **/
-         class ResetPasswordResponse extends Response {
+         class ResetPasswordResponse extends OK {
          };
 
         /**
@@ -75,7 +75,7 @@ module omero {
          * For non-administrators, most values for all sessions other than
          * those belonging to that user will be nulled.
          **/
-        class CurrentSessionsResponse extends Response {
+        class CurrentSessionsResponse extends OK {
 
             /**
              * {@link omero.model.Session} objects loaded from

--- a/src/main/slice/omero/cmd/FS.ice
+++ b/src/main/slice/omero/cmd/FS.ice
@@ -76,7 +76,7 @@ module omero {
          * will be returned under normal conditions, otherwise a {@link ERR}
          * will be returned.
          **/
-        class OriginalMetadataRequest extends OK {
+        class OriginalMetadataRequest extends Request {
             long imageId;
         };
 

--- a/src/main/slice/omero/cmd/FS.ice
+++ b/src/main/slice/omero/cmd/FS.ice
@@ -60,7 +60,7 @@ module omero {
          * will be returned under normal conditions, otherwise a {@link ERR}
          * will be returned.
          **/
-        class FindPyramidsResponse extends Response {
+        class FindPyramidsResponse extends OK {
 
             /**
              * The image IDs corresponding to the pyramid
@@ -76,7 +76,7 @@ module omero {
          * will be returned under normal conditions, otherwise a {@link ERR}
          * will be returned.
          **/
-        class OriginalMetadataRequest extends Request {
+        class OriginalMetadataRequest extends OK {
             long imageId;
         };
 
@@ -87,7 +87,7 @@ module omero {
          * Pre-FS images will have {@link #filesetAnnotationId} set; otherwise
          * {@link #filesetId} will be set.
          **/
-        class OriginalMetadataResponse extends Response {
+        class OriginalMetadataResponse extends OK {
 
             /**
              * Set to the id of the {@link omero.model.Fileset} that this
@@ -134,7 +134,7 @@ module omero {
         /**
          * The used files associated with a pre-FS image.
          **/
-        class UsedFilesResponsePreFs extends Response {
+        class UsedFilesResponsePreFs extends OK {
             /**
              * The original file IDs of any archived files associated with
              * the image.
@@ -157,7 +157,7 @@ module omero {
         /**
          * The used files associated with an FS image.
          **/
-        class UsedFilesResponse extends Response {
+        class UsedFilesResponse extends OK {
             /**
              * The original file IDs of any binary files associated with the
              * image's particular series.

--- a/src/main/slice/omero/cmd/Graphs.ice
+++ b/src/main/slice/omero/cmd/Graphs.ice
@@ -277,7 +277,7 @@ module omero {
          *   Thumbnail for the image thumbnails
          * The above map values are broken down by owner-group keys.
          **/
-        class DiskUsage2Response extends Response {
+        class DiskUsage2Response extends OK {
             omero::api::LongPairToStringIntMap fileCountByReferer;
             omero::api::LongPairToStringLongMap bytesUsedByReferer;
             omero::api::LongPairIntMap totalFileCount;


### PR DESCRIPTION
It looked to me as if these Response objects clearly indicate success thus should extend "OK". Happy to revert any for which there is doubt.