### PR TITLE
Remove from comments confusing references to OMERO 4.x code.

### DIFF
--- a/src/main/slice/omero/cmd/Graphs.ice
+++ b/src/main/slice/omero/cmd/Graphs.ice
@@ -38,13 +38,11 @@ module omero {
 
                 /**
                  * Include in the operation all children of these types.
-                 * Cf. use of HARD in GraphModify's options.
                  **/
                 omero::api::StringSet includeType;
 
                 /**
                  * Include in the operation no children of these types.
-                 * Cf. use of KEEP in GraphModify's options.
                  **/
                 omero::api::StringSet excludeType;
 


### PR DESCRIPTION
Enough time has passed that these comments referencing deprecated then removed classes probably serve more to confuse than to assist.