### PR TITLE
Javadoc

### DIFF
--- a/src/main/ice36/ome/services/blitz/fire/TopicManager.java
+++ b/src/main/ice36/ome/services/blitz/fire/TopicManager.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -31,7 +29,7 @@ public interface TopicManager extends ApplicationListener {
 
     /**
      * Enforces <em>no</em> security constraints. For the moment, that is the
-     * responsibility of application code. WILL CHANGE>
+     * responsibility of application code. WILL CHANGE
      */
     public void register(String topicName, Ice.ObjectPrx prx, boolean strict)
     throws omero.ServerError;

--- a/src/main/java/loci/ome/io/OMECredentials.java
+++ b/src/main/java/loci/ome/io/OMECredentials.java
@@ -60,7 +60,9 @@ public class OMECredentials {
 
   /**
    * Get credentials from a string. The following two formats are recognized:
-   * <code>ip.address?port=54321&username=login&password=secret&id=12345</code>
+   * {@code
+   * ip.address?port=54321&username=login&password=secret&id=12345
+   * }
    * or:
    * <pre>
    * server=ip.address

--- a/src/main/java/ome/formats/OMEROMetadataStoreClient.java
+++ b/src/main/java/ome/formats/OMEROMetadataStoreClient.java
@@ -1,6 +1,4 @@
 /*
- * ome.formats.OMEROMetadataStoreClient
- *
  *------------------------------------------------------------------------------
  *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
  *
@@ -1642,7 +1640,7 @@ public class OMEROMetadataStoreClient
      * Maps the user's groups for use by ScreenLogin.registerGroup()
      * Also strips system groups from this map
      *
-     * @return map of group id & name
+     * @return map of group id and name
      * @throws ServerError if the groups could not be mapped
      */
     public Map<Long, String> mapUserGroups() throws ServerError

--- a/src/main/java/ome/services/blitz/impl/AbstractPyramidServant.java
+++ b/src/main/java/ome/services/blitz/impl/AbstractPyramidServant.java
@@ -103,8 +103,8 @@ public abstract class AbstractPyramidServant extends AbstractCloseableAmdServant
     }
 
     /**
-     * This is a fairly brittle mapping from the List<List<Integer>> created by
-     * the PixelBuffers to the List<ResolutionDescription> which is remotely
+     * This is a fairly brittle mapping from the {@code List<List<Integer>>} created by
+     * the PixelBuffers to the {@code List<ResolutionDescription>} which is remotely
      * provided by Blitz. The assumption is that much of these two levels will
      * be refactored together and therefore that shouldn't be a long-term
      * problem.

--- a/src/main/java/omero/util/RPSTileLoop.java
+++ b/src/main/java/omero/util/RPSTileLoop.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -78,9 +76,9 @@ public class RPSTileLoop extends TileLoop {
      * @param iteration Invoker to call for each tile.
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
-     * <code>x + tileWidth > sizeX</code>.
+     * {@code x + tileWidth > sizeX}
      * @param tileHeight <b>Maximum</b> height of the tile requested. The tile
-     * request itself will be smaller if <code>y + tileHeight > sizeY</code>.
+     * request itself will be smaller if {@code y + tileHeight > sizeY}.
      * @return The total number of tiles iterated over.
      */
     public int forEachTile(int tileWidth, int tileHeight,

--- a/src/main/java/omero/util/TileLoop.java
+++ b/src/main/java/omero/util/TileLoop.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -31,9 +29,9 @@ public abstract class TileLoop {
      * @param iteration Invoker to call for each tile.
      * @param tileWidth <b>Maximum</b> width of the tile requested. The tile
      * request itself will be smaller than the original tile width requested if
-     * <code>x + tileWidth > sizeX</code>.
+     * {@code x + tileWidth > sizeX}.
      * @param tileHeight <b>Maximum</b> height of the tile requested. The tile
-     * request itself will be smaller if <code>y + tileHeight > sizeY</code>.
+     * request itself will be smaller if {@code y + tileHeight > sizeY}.
      * @return The total number of tiles iterated over.
      */
     public int forEachTile(int sizeX, int sizeY,

--- a/src/main/java/omero/util/TileLoopIteration.java
+++ b/src/main/java/omero/util/TileLoopIteration.java
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  */
@@ -25,9 +23,9 @@ public interface TileLoopIteration
     * timepoint counters.
     * @param tileWidth Width of the tile requested. The tile request
     * itself may be smaller than the original tile width requested if
-    * <code>x + tileWidth > sizeX</code>.
+    * {@code x + tileWidth > sizeX}.
     * @param tileHeight Height of the tile requested. The tile request
-    * itself may be smaller if <code>y + tileHeight > sizeY</code>.
+    * itself may be smaller if {@code y + tileHeight > sizeY}.
     * @param tileCount Counter of the tile since the beginning of the loop.
     */
     void run(TileData data, int z, int c, int t, int x, int y,

--- a/src/main/slice/omero/API.ice
+++ b/src/main/slice/omero/API.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -101,7 +99,7 @@ module omero {
             /**
              * Provides a list of all valid security contexts for this session.
              * Each of the returned {@link omero.model.IObject} instances can
-             * be passed to {@link #setSecurityContext}.
+             * be passed to {@code setSecurityContext}.
              **/
             IObjectList getSecurityContexts() throws ServerError;
 
@@ -122,7 +120,7 @@ module omero {
              *
              * <p> Passing an unloaded version of either object type will change
              * the way the current session operates. Note: only objects which
-             * are returned by the {@link #getSecurityContexts} method are
+             * are returned by the {@code getSecurityContext} method are
              * considered valid. Any other instance will cause an exception to
              * be thrown. </p>
              *
@@ -267,9 +265,9 @@ module omero {
              * case the returned long value will be non-zero.
              *
              * Specifically, the bit representing the 0-based index will be 1:
-             *
+             * {@code
              *        if (retval & 1&lt;&lt;idx == 1&lt;&lt;idx) { // not alive }
-             *
+             * }
              * Except for fatal server or session errors, this method should never
              * throw an exception.
              **/

--- a/src/main/slice/omero/Collections.ice
+++ b/src/main/slice/omero/Collections.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/Constants.ice
+++ b/src/main/slice/omero/Constants.ice
@@ -95,7 +95,7 @@ module omero {
     /**
      * Server-side names used for each of the services
      * defined in API.ice. These names can be used in
-     * the ServiceFactory.getByName() and createByName()
+     * the {@code ServiceFactory.getByName} and {@code createByName}
      * methods.
      **/
     const string ADMINSERVICE     = "omero.api.IAdmin";
@@ -164,7 +164,7 @@ module omero {
     };
 
     /**
-     * Log levels used by {@link RawAccessRequest}'s {@code log} command for {@code path}.
+     * Log levels used by {@code RawAccessRequest}'s {@code log} command for {@code path}.
      **/
     enum LogLevel { Trace, Debug, Info, Warn, Error };
 
@@ -246,43 +246,43 @@ module omero {
     module permissions {
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the link restriction has been applied to the current object.
        **/
       const int LINKRESTRICTION = 0;
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the edit restriction has been applied to the current object.
        **/
       const int EDITRESTRICTION = 1;
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the delete restriction has been applied to the current object.
        **/
       const int DELETERESTRICTION = 2;
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the annotate restriction has been applied to the current object.
        **/
       const int ANNOTATERESTRICTION = 3;
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the chgrp restriction has been applied to the current object.
        **/
       const int CHGRPRESTRICTION = 4;
 
       /**
-       * Index into the {@link omero.model.Permissions#restrictions}
-       * {@link omero.api.BoolArray} field to test whether or not
+       * Index into the {@code omero.model.Permissions.restrictions}
+       * {@code omero.api.BoolArray} field to test whether or not
        * the chown restriction has been applied to the current object.
        **/
       const int CHOWNRESTRICTION = 5;

--- a/src/main/slice/omero/FS.ice
+++ b/src/main/slice/omero/FS.ice
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 #ifndef OMERO_FS
 #define OMERO_FS
 

--- a/src/main/slice/omero/Internal.ice
+++ b/src/main/slice/omero/Internal.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/ModelF.ice
+++ b/src/main/slice/omero/ModelF.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/ROMIO.ice
+++ b/src/main/slice/omero/ROMIO.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/RTypes.ice
+++ b/src/main/slice/omero/RTypes.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -98,12 +96,14 @@ module omero {
    * Extends RString and simply provides runtime
    * information to the server that this string
    * is intended as a ""protected"" class parameter. Used especially
-   * by {@link omero.system.ParamMap} (omero/System.ice)
+   * by {@code omero.system.ParamMap} (omero/System.ice)
    * 
    * Usage:
    * <pre>
+   * {@code
    *   omero::RClass c = ...; // from service
    *   if (!c.null && c.val.equals("Image")) { ... }
+   * }
    * </pre>
    **/
   ["protected"] class RClass extends RString
@@ -123,13 +123,12 @@ module omero {
   // Collections
 
   /**
-   * Simple sequence of {@link RType} instances. Note: when passing
-   * an {@link RTypeSeq} over the wire, null sequence is maintained and
+   * Simple sequence of {@code RType} instances. Note: when passing
+   * an {@code RTypeSeq} over the wire, null sequence is maintained and
    * will be turned into an empty sequence. If nullability is
-   * required, see the {@link RCollection} types.
+   * required, see the {@code RCollection} types.
    *
    * @see RCollection
-   * @see RTypeDict
    */
   ["java:type:java.util.ArrayList<omero.RType>:java.util.List<omero.RType>"]
   sequence<RType> RTypeSeq;
@@ -165,7 +164,7 @@ module omero {
   };
 
   /**
-   * {@link RCollection} mapped to an array on the server of a type given
+   * {@code RCollection} mapped to an array on the server of a type given
    * by a random member of the RTypeSeq. Only pass consistent arrays!
    * homogeneous lists.
    **/
@@ -174,34 +173,33 @@ module omero {
   };
 
   /**
-   * {@link RCollection} mapped to a java.util.List on the server
+   * {@code RCollection} mapped to a java.util.List on the server
    **/
   ["protected"] class RList extends RCollection
   {
   };
 
   /**
-   * {@link RCollection} mapped to a java.util.HashSet on the server
+   * {@code RCollection} mapped to a java.util.HashSet on the server
    **/
   ["protected"] class RSet extends RCollection
   {
   };
 
   /**
-   * Simple dictionary of {@link RType} instances. Note: when passing
+   * Simple dictionary of {@code RType} instances. Note: when passing
    * an RTypeDict over the wire, a null map will not be maintained and
    * will be turned into an empty map. If nullability is
-   * required, see the {@link RMap} type.
+   * required, see the {@code RMap} type.
    **/
   ["java:type:java.util.HashMap<String,omero.RType>"]
   dictionary<string,omero::RType> RTypeDict;
 
   /**
-   * Similar to {@link RCollection}, the {@link RMap} class permits the passing
-   * of a possible null {@link RTypeDict} where any other {@link RType} is
+   * Similar to {@code RCollection}, the {@code RMap} class permits the passing
+   * of a possible null {@code RTypeDict} where any other {@code RType} is
    * expected.
    *
-   * @see RTypeDict
    * @see RCollection
    **/
   ["protected"] class RMap extends RType {

--- a/src/main/slice/omero/Repositories.ice
+++ b/src/main/slice/omero/Repositories.ice
@@ -1,10 +1,8 @@
 /*
-*   $Id$
-*
-*   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
-*   Use is subject to license terms supplied in LICENSE.txt
-*
-*/
+ *   Copyright 2009-2013 Glencoe Software, Inc. All rights reserved.
+ *   Use is subject to license terms supplied in LICENSE.txt
+ *
+ */
 
 #ifndef OMERO_REPOSITORY_ICE
 #define OMERO_REPOSITORY_ICE
@@ -41,7 +39,7 @@ module omero {
         /**
          * Specifies that a file is located at the given location
          * that is not otherwise known by the repository. A
-         * subsequent call to {@link Repository.register} will create
+         * subsequent call to {@code Repository.register} will create
          * the given file. The mimetype field of the file may or
          * may not be set. If it is set, clients are suggested to
          * either omit the mimetype argument to the register method
@@ -118,7 +116,7 @@ module omero {
             /**
              * Returns true if the file or path exists within the repository.
              * In other words, if a call on `dirname path` to
-             * {@link #listFiles} would return an object for this path.
+             * {@code listFiles} would return an object for this path.
              **/
             bool fileExists(string path) throws ServerError;
 
@@ -132,7 +130,7 @@ module omero {
             void makeDir(string path, bool parents) throws ServerError;
 
             /**
-             * Similar to {@link #list} but recursive and returns only
+             * Similar to {@code list} but recursive and returns only
              * primitive values for the file at each location. Guaranteed for
              * each path is only the values id and mimetype.
              *
@@ -140,6 +138,7 @@ module omero {
              * call to treeList("/user_1/dir0") might look something like:
              *
              * <pre>
+             * {@code
              *  {
              *      "/user_1/dir0/file1.txt" :
              *      {
@@ -165,6 +164,7 @@ module omero {
              *           }
              *     }
              *  }
+             * }
              * </pre>
              **/
             omero::RMap treeList(string path) throws ServerError;
@@ -198,7 +198,7 @@ module omero {
         };
 
         /**
-         * Returned by {@link ManagedRepository#importFileset} with
+         * Returned by {@code ManagedRepository.importFileset} with
          * the information needed to proceed with an FS import.
          * For the examples that follow, assume that the used
          * files passed to importFileset were:
@@ -229,7 +229,7 @@ module omero {
              * Parsed string names which should be used by the
              * clients during upload. This array will be of the
              * same length as the argument passed to
-             * {@link ManagedRepository#importFileset} but will have
+             * {@code ManagedRepository.importFileset} but will have
              * shortened paths.
              *
              * <pre>
@@ -294,7 +294,7 @@ module omero {
              omero::model::ChecksumAlgorithm checksumAlgorithm;
 
              /**
-              * If set, the {@link ImportProcess*} and the {@link Handle*}
+              * If set, the {@code ImportProcess*} and the {@code Handle*}
               * associated with the import will be closed as soon as complete.
               * This will prevent clients from finding out the status of the
               * import itself.
@@ -320,11 +320,11 @@ module omero {
             /**
              * Step 1: Returns a RawFileStore that can be used to upload one of
              * the used files. The index is the same as the used file listed in
-             * {@link ImportLocation}. {@link omero.api.RawFileStore#close}
+             * {@code ImportLocation}. {@code omero.api.RawFileStore.close}
              * should be called once all data has been transferred. If the
-             * file must be re-written, call {@link #getUploader} with the
+             * file must be re-written, call {@code getUploader} with the
              * same index again. Once all uploads have been completed,
-             * {@link verifyUpload} should be called to initiate background
+             * {@code verifyUpload} should be called to initiate background
              * processing
              **/
              omero::api::RawFileStore* getUploader(int i) throws ServerError;
@@ -335,7 +335,7 @@ module omero {
              * uploaded. If this passes then a {@link omero.cmd.Handle}
              * proxy is returned, which completes all the necessary import
              * steps. A successful import will return an
-             * {@link ImportResponse}. Otherwise, some {@link omero.cmd.ERR}
+             * {@code ImportResponse}. Otherwise, some {@link omero.cmd.ERR}
              * will be returned.
              **/
              omero::cmd::Handle* verifyUpload(omero::api::StringSet hash) throws ServerError;
@@ -352,10 +352,10 @@ module omero {
 
             /**
              * Reacquire the handle which was returned by
-             * {@link #verifyUpload}. This is useful in case a new
+             * {@code verifyUpload}. This is useful in case a new
              * client is re-attaching to a running import.
              * From the {@link omero.cmd.Handle} instance, the
-             * original {@link ImportRequest} can also be found.
+             * original {@code ImportRequest} can also be found.
              **/
              omero::cmd::Handle* getHandle() throws ServerError;
 
@@ -369,7 +369,7 @@ module omero {
         /**
          * Command object which will be used to create
          * the {@link omero.cmd.Handle} instances passed
-         * back by the {@link ImportProcess}.
+         * back by the {@code ImportProcess}.
          **/
         class ImportRequest extends omero::cmd::Request {
 
@@ -405,18 +405,18 @@ module omero {
 
             /**
              * {@link ImportSettings} which are provided by the
-             * client on the call to {@link ManagedRepository#importFileset}.
+             * client on the call to {@code ManagedRepository.importFileset}.
              **/
              ImportSettings settings;
 
             /**
              * {@link ImportLocation} which is calculated during
-             * the call to {@link ManagedRepository#importFileset}.
+             * the call to {@code ManagedRepository.importFileset}.
              **/
              ImportLocation location;
 
             /**
-             * {@link OriginalFile} object representing the import log file.
+             * {@link omero.model.OriginalFile} object representing the import log file.
              **/
              omero::model::OriginalFile logFile;
 
@@ -465,7 +465,7 @@ module omero {
 
             /**
              * For clients without access to Bio-Formats, the simplified
-             * {@link #importPaths} method allows passing solely the absolute
+             * {@code importPaths} method allows passing solely the absolute
              * path of the files to be uploaded (no directories) and all
              * configuration happens server-side. Much of the functionality
              * provided via {@link omero.model.Fileset} and

--- a/src/main/slice/omero/Repositories.ice
+++ b/src/main/slice/omero/Repositories.ice
@@ -138,33 +138,33 @@ module omero {
              * call to treeList("/user_1/dir0") might look something like:
              *
              * <pre>
-             * {@code
-             *  {
-             *      "/user_1/dir0/file1.txt" :
-             *      {
-             *          "id":10,
-             *          "mimetype":
-             *          "binary",
-             *          "size": 10000L
-             *      },
+             *  {@code
+             *    {
+             *        "/user_1/dir0/file1.txt" :
+             *        {
+             *            "id":10,
+             *            "mimetype":
+             *            "binary",
+             *            "size": 10000L
+             *        },
              *
-             *      "/user_1/dir0/dir1" :
-             *      {
-             *          "id": 100,
-             *          "mimetype": "Directory",
-             *          "size": 0L,
-             *          "files":
-             *          {
-             *              "/user_1/dir0/dir1/file1indir.txt" :
-             *              {
-             *                  "id": 1,
-             *                  "mimetype": "png",
-             *                  "size": 500
-             *              }
-             *           }
-             *     }
+             *        "/user_1/dir0/dir1" :
+             *        {
+             *            "id": 100,
+             *            "mimetype": "Directory",
+             *            "size": 0L,
+             *            "files":
+             *            {
+             *                "/user_1/dir0/dir1/file1indir.txt" :
+             *                {
+             *                    "id": 1,
+             *                    "mimetype": "png",
+             *                    "size": 500
+             *                }
+             *             }
+             *         }
+             *    }
              *  }
-             * }
              * </pre>
              **/
             omero::RMap treeList(string path) throws ServerError;

--- a/src/main/slice/omero/Scripts.ice
+++ b/src/main/slice/omero/Scripts.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -46,7 +44,7 @@ module omero {
 
     /**
      * Sequences cannot subclass other types, so the Plane
-     * class extends {@link Internal} and wraps a {@link Bytes2D} instance.
+     * class extends {@code Internal} and wraps a {@code Bytes2D} instance.
      **/
     class Plane extends Internal {
         Bytes2D data;
@@ -116,7 +114,7 @@ module omero {
              * Whether or not a script will require this value to be present
              * in the input or output. If an input is missing or None when
              * non-optional, then a {@link omero.ValidationException} will be
-             * thrown on {@link #processJob}. A missing output param will be
+             * thrown on {@code processJob}. A missing output param will be
              * marked after execution.
              **/
             bool \optional;
@@ -189,8 +187,8 @@ module omero {
 
             /**
              * An enumeration of acceptable values which can be used
-             * for this parameter. If {@link #min} and {@link #max} are set,
-             * this value will be ignored. If {@link prototype} is an
+             * for this parameter. If {@code min} and {@code max} are set,
+             * this value will be ignored. If {@code prototype} is an
              * {@link omero.RCollection} or {@link omero.RMap} instance, then
              * the values in this {@link omero.RList} will be of the member
              * types of the collection or map, and not a collection or map
@@ -202,7 +200,7 @@ module omero {
              * Defines the grouping strategy for this {@link Param}.
              *
              * <p>
-             * A set of {@link Param} objects in a single {@link JobParams} can
+             * A set of {@code Param} objects in a single {@code JobParams} can
              * use dot notation to specify that they belong together,
              * and in which order they should be presented to the user.
              * </p>
@@ -274,9 +272,9 @@ module omero {
              * </p>
              *
              * <p>
-             * {@link omero.constants.namespaces.NSDOWNLOAD}, for example,
+             * {@code omero.constants.namespaces.NSDOWNLOAD}, for example,
              * indicates that users may want to download the resulting
-             * file. The {@link #prototype} of the {@link Param} should be one
+             * file. The {@code prototype} of the {@code Param} should be one
              * of: {@link omero.model.OriginalFile},
              * {@link omero.model.FileAnnotation},
              * or an annotation link (like
@@ -386,7 +384,7 @@ module omero {
             ParamMap outputs;
 
             /**
-             * {@link omero.model.Format#value} of the stdout stream produced
+             * {@code omero.model.Format.value} of the stdout stream produced
              * by the script. If this value is not otherwise set (i.e. is
              * None), the default of "text/plain" will be set. This is
              * typically a good idea if the script uses "print" or the logging
@@ -400,7 +398,7 @@ module omero {
             string stdoutFormat;
 
             /**
-             * {@link omero.model.Format#value} of the stderr stream produced by
+             * {@code omero.model.Format.value} of the stderr stream produced by
              * the script. If this value is not otherwise set (i.e. is None),
              * the default of "text/plain" will be set. This is typically a
              * good idea if the script uses "print" or the logging module.
@@ -414,7 +412,7 @@ module omero {
 
             /**
              * Defines machine readable interpretations for this
-             * {@link JobParams}.
+             * {@code JobParams}.
              *
              * <p>
              * Where the description field should provide information for
@@ -508,10 +506,10 @@ module omero {
         };
 
         /**
-         * Extension of the {@link Process} interface which is returned by
-         * {@link IScript} when an {@link omero.model.ScriptJob} is launched.
-         * It is critical that instances of (@link ScriptProcess} are closed
-         * on completetion. See the {@link #close} method for more information.
+         * Extension of the {@code Process} interface which is returned by
+         * {@code IScript} when an {@link omero.model.ScriptJob} is launched.
+         * It is critical that instances of (@code ScriptProcess} are closed
+         * on completion. See the {@link #close} method for more information.
          **/
         interface ScriptProcess extends Process {
 
@@ -544,7 +542,7 @@ module omero {
              * Closes this process and frees server resources attached to it.
              * If the detach argument is True, then the background process
              * will continue executing. The user can reconnect to the process
-             * via the {@link IScript} service.
+             * via the {@code IScript} service.
              *
              * If the detach argument is False, then the background process
              * will be shutdown immediately, and all intermediate results
@@ -566,7 +564,7 @@ module omero {
 
         /**
          * Internal callback interface which is passed to the
-         * {@link Processor#accepts} method
+         * {@code Processor.accepts} method
          * to query whether or not a processor will accept a certain operation.
          **/
         interface ProcessorCallback {
@@ -588,9 +586,9 @@ module omero {
 
             /**
              * Called by {@link omero.grid.SharedResources} to find a suitable
-             * target for {@link omero.grid.SharedResources#acquireProcessor}.
+             * target for {@code omero.grid.SharedResources.acquireProcessor}.
              * New processor instances are added to the checklist by using
-             * {@link omero.grid.SharedResources#addProcessor}. All processors
+             * {@code omero.grid.SharedResources.addProcessor}. All processors
              * must respond with their session uuid in order to authorize
              * the action.
              **/
@@ -603,7 +601,7 @@ module omero {
             /**
              * Used by servers to find out what jobs are still active.
              * Response will be sent to
-             * {@link ProcessorCallback#responseRunning}
+             * {@code ProcessorCallback.responseRunning}
              **/
             idempotent
             void requestRunning(ProcessorCallback* cb);
@@ -611,7 +609,7 @@ module omero {
             /**
              * Parses a job and returns metadata definition required
              * for properly submitting the job. This object will be
-             * cached by the server, and passed back into {@link #processJob}
+             * cached by the server, and passed back into {@code processJob}
              **/
             idempotent
             JobParams parseJob(string session, omero::model::Job jobObject) throws ServerError;
@@ -619,8 +617,8 @@ module omero {
             /**
              * Starts a process based on the given job
              * If this processor cannot handle the given job, a
-             * null process will be returned. The {@param params} argument
-             * was created by a previously call to {@link #parseJob}.
+             * null process will be returned. The {@code params} argument
+             * was created by a previously call to {@code parseJob}.
              **/
             Process* processJob(string session, JobParams params, omero::model::Job jobObject) throws ServerError;
 

--- a/src/main/slice/omero/ServerErrors.ice
+++ b/src/main/slice/omero/ServerErrors.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -186,7 +184,7 @@ module omero
     };
 
   /**
-   * Thrown when the password for a user has expried. Use: ISession.changeExpiredCredentials()
+   * Thrown when the password for a user has expired. Use: ISession.changeExpiredCredentials()
    * and login as guest. This does -not- subclass from the omero.ServerError class because the
    * Ice Glacier2::SessionManager interface can only throw CCSEs.
    */
@@ -262,7 +260,7 @@ module omero
   /**
    * Too many simultaneous database users. This implies that a
    * connection to the database could not be acquired, no data
-   * was saved or modifed. Clients may want to wait the given
+   * was saved or modified. Clients may want to wait the given
    * backOff period, and retry.
    */
   exception DatabaseBusyException extends ConcurrencyException

--- a/src/main/slice/omero/ServicesF.ice
+++ b/src/main/slice/omero/ServicesF.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -63,7 +61,7 @@ module omero {
             * stateful service and removes its name from the object adapter.
             * Any further method calls will fail with a Ice::NoSuchObjectException.
             *
-            * Note: with JavaEE, the close method was called publically,
+            * Note: with JavaEE, the close method was called publicly,
             * and internally this called destroy(). As of the OmeroBlitz
             * migration, this functionality has been combined.
             **/

--- a/src/main/slice/omero/SharedResources.ice
+++ b/src/main/slice/omero/SharedResources.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -47,7 +45,7 @@ module omero {
             /**
              * Unregisters a {@link omero.grid.Processor} from Storm
              * notifications. If the processor was not already registered via
-             * {@link #addProcessor} this is a no-op.
+             * {@code addProcessor} this is a no-op.
              **/
             void
                 removeProcessor(omero::grid::Processor* proc)
@@ -72,9 +70,9 @@ module omero {
                 throws ServerError;
 
             /**
-             * Returns true if a {@link Tables} service is active in the grid.
-             * If this value is false, then all calls to {@link #newTable}
-             * or {@link #openTable} will either fail or return null (possibly
+             * Returns true if a {@code Tables} service is active in the grid.
+             * If this value is false, then all calls to {@code #ewTable}
+             * or {@code openTable} will either fail or return null (possibly
              * blocking while waiting for a service to startup)
              **/
             idempotent

--- a/src/main/slice/omero/System.ice
+++ b/src/main/slice/omero/System.ice
@@ -65,7 +65,7 @@ module omero {
      *                   Note: servers may choose to impose a
      *                   maximum limit.
      *
-     *  start/endTime := (some) objects queried shoud have been
+     *  start/endTime := (some) objects queried should have been
      *                   created and/or modified within time span.
      *
      **/

--- a/src/main/slice/omero/Tables.ice
+++ b/src/main/slice/omero/Tables.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -44,7 +42,7 @@ module omero {
         /**
          * Base type for dealing working with tabular data. For efficiency,
          * data is grouped by type, i.e. column. These value objects are passed
-         * through the {@link Table} interface.
+         * through the {@code Table} interface.
          **/
         class Column {
 
@@ -178,7 +176,7 @@ module omero {
             /**
              * Read the given rows of data.
              *
-             * {@param rowNumbers} must contain at least one element or an
+             * @param rowNumbers must contain at least one element or an
              * {@link omero.ApiUsageException} will be thrown.
              **/
             idempotent
@@ -226,8 +224,8 @@ module omero {
             /**
              * Allows the user to modify a Data instance passed back
              * from a query method and have the values modified. It
-             * is critical that the {@link Data#lastModification} and the
-             * {@link Data#rowNumbers} fields are properly set. An exception
+             * is critical that the {@code Data.lastModification} and the
+             * {@code Data.rowNumbers} fields are properly set. An exception
              * will be thrown if the data has since been modified.
              **/
             void update(Data modifiedData)

--- a/src/main/slice/omero/api/Exporter.ice
+++ b/src/main/slice/omero/api/Exporter.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -20,7 +18,8 @@ module omero {
          * Stateful service for generating OME-XML or OME-TIFF from data stored
          * in OMERO. Intended usage:
          * <pre>
-         *
+         * {@code
+
          *   ExporterPrx e = sf.createExporter();
          *
          *   // Exporter is currently in the <i>configuration</i> state
@@ -54,7 +53,7 @@ module omero {
          *       read += buf.length;
          *   }
          *   e.close();
-         *
+         * }
          * </pre>
          **/
         ["ami", "amd"] interface Exporter extends StatefulServiceInterface {

--- a/src/main/slice/omero/api/IAdmin.ice
+++ b/src/main/slice/omero/api/IAdmin.ice
@@ -139,7 +139,7 @@ module omero {
                  * Looks up {@link omero.model.Experimenter} experimenters who
                  * use LDAP authentication  (has set dn on password table).
                  *
-                 * @param id if of the Experimenter. Not null.
+                 * @param id id of the Experimenter. Not null.
                  * @return Experimenter. Never null.
                  */
                 idempotent string lookupLdapAuthExperimenter(long id) throws ServerError;

--- a/src/main/slice/omero/api/IAdmin.ice
+++ b/src/main/slice/omero/api/IAdmin.ice
@@ -139,6 +139,7 @@ module omero {
                  * Looks up {@link omero.model.Experimenter} experimenters who
                  * use LDAP authentication  (has set dn on password table).
                  *
+                 * @param id if of the Experimenter. Not null.
                  * @return Experimenter. Never null.
                  */
                 idempotent string lookupLdapAuthExperimenter(long id) throws ServerError;
@@ -203,12 +204,9 @@ module omero {
                  * not have the proper id nor the proper omeName (which is
                  * immutable). To change the users default group (which is the
                  * only other customizable option), use
-                 * {@link #setDefaultGroup}
+                 * {@code setDefaultGroup}
                  *
                  * @see #setDefaultGroup
-                 * @param experimenter A data transfer object. Only the fields:
-                 *        firstName, middleName, lastName, email, and
-                 *        institution are checked. Not null.
                  */
                 void updateSelf(omero::model::Experimenter experimenter) throws ServerError;
 
@@ -245,7 +243,7 @@ module omero {
                 /**
                  * Retrieves the {@link omero.model.OriginalFile} object
                  * attached to this user as specified by
-                 * {@link #uploadMyUserPhoto}.
+                 * {@code uploadMyUserPhoto}.
                  * The return value is order by the most recently modified
                  * file first.
                  *
@@ -259,7 +257,7 @@ module omero {
                  * The root and guest experimenters may not be renamed.
                  *
                  * Before a SecurityViolation would be thrown, however, this
-                 * method will pass to {@link #updateSelf} <em>if</em> the
+                 * method will pass to {@code #updateSelf} <em>if</em> the
                  * current user matches the given experimenter.
                  *
                  * @param experimenter the Experimenter to update.
@@ -381,13 +379,13 @@ module omero {
 
                 /**
                  * Creates and returns a new group. The
-                 * {@link omero.model.Details#setPermissions} method should be
+                 * {@code omero.model.Details.setPermissions} method should be
                  * called on the instance which is passed. The given
                  * {@link omero.model.Permissions} will become the default for
                  * all objects created while logged into this group, possibly
                  * modified by the user's umask settings.
                  * If no permissions is set, the default will be
-                 * {@link omero.model.Permissions#USER_PRIVATE},
+                 * {@code omero.model.Permissions.USER_PRIVATE},
                  * i.e. a group in which no user can see the other group
                  * member's data.
                  *
@@ -395,7 +393,7 @@ module omero {
                  *
                  * @param group  a new
                  * {@link omero.model.ExperimenterGroup} instance. Not null.
-                 * @return id of the newly created {@link ExperimenterGroup}
+                 * @return id of the newly created {@link omero.model.ExperimenterGroup}
                  */
                 long createGroup(omero::model::ExperimenterGroup group) throws ServerError;
 
@@ -413,7 +411,7 @@ module omero {
                  * <ul>
                  * <li>The root experimenter is required to be in both the
                  * user and system groups.</li>
-                 * <li>An experimenter may not remove themself from the user
+                 * <li>An experimenter may not remove themselves from the user
                  * or system group.</li>
                  * <li>An experimenter may not be a member of only the user
                  * group, some other group is also required as the default
@@ -537,7 +535,7 @@ module omero {
                  * <em>Warning:</em>This method requires the user to be
                  * authenticated with a password and not with a one-time
                  * session id. To avoid this problem, use
-                 * {@link #changePasswordWithOldPassword}.
+                 * {@code changePasswordWithOldPassword}.
                  * </p>
                  *
                  * See also <a href="https://trac.openmicroscopy.org/ome/ticket/911">ticket 911</a>

--- a/src/main/slice/omero/api/IConfig.ice
+++ b/src/main/slice/omero/api/IConfig.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -46,14 +44,14 @@ module omero {
                  * followed by a hyphen: ACME-0.0.1 and any build information
                  * should follow the patch number also with a hyphen:
                  * 4.0.0-RC1. These values will be removed by
-                 * {@link #getVersion}
+                 * {@code getVersion}
                  */
                 idempotent string getVersion() throws ServerError;
 
                 /**
                  * Retrieves a configuration value from the backend store.
                  * Permissions applied to the configuration value may cause a
-                 * {@link SecurityViolation} to be thrown.
+                 * {@link omero.SecurityViolation} to be thrown.
                  *
                  * @param key The non-null name of the desired configuration
                  *        value
@@ -87,7 +85,7 @@ module omero {
                 idempotent omero::api::StringStringMap getConfigDefaults() throws ServerError;
 
                 /**
-                 * Retrieves configuration values like {@link #getConfigValues}
+                 * Retrieves configuration values like {@code getConfigValues}
                  * but only those with the prefix <i>omero.client</i>.
                  *
                  * @return a map from the found keys to the linked values.
@@ -106,12 +104,12 @@ module omero {
                 /**
                  * Sets a configuration value in the backend store.
                  * Permissions applied to the configuration value may cause a
-                 * {@link SecurityViolation} to be thrown. If the value is
+                 * {@link omero.SecurityViolation} to be thrown. If the value is
                  * null or empty, then the configuration will be removed in
                  * all writable configuration sources. If the configuration is
                  * set in a non-modifiable source (e.g. in a property file on
                  * the classpath), then a subsequent call to
-                 * {@link #getConfigValue} will return that value.
+                 * {@code getConfigValue} will return that value.
                  *
                  * @param key The non-null name of the desired configuration
                  *        value
@@ -122,7 +120,7 @@ module omero {
                 idempotent void setConfigValue(string key, string value) throws ServerError;
 
                 /**
-                 * Calls {@link #setConfigValue} if and only if the
+                 * Calls {@code setConfigValue} if and only if the
                  * configuration property is currently equal to the test
                  * argument. If the test is null or empty, then the
                  * configuration property will be set only if missing.
@@ -152,7 +150,7 @@ module omero {
                 /**
                  * Checks the database for its time using a SELECT statement.
                  *
-                 * @return Non-null {@link RTime} representation of the
+                 * @return Non-null {@link omero.RTime} representation of the
                  *         database time.
                  * @throws InternalException though any call can throw an
                  *         InternalException it is more likely that this can
@@ -168,7 +166,7 @@ module omero {
                  * variant depending on whether the service is clustered or
                  * not.
                  *
-                 * @return Non-null {@link RTime} representation of the
+                 * @return Non-null {@link omero.RTime} representation of the
                  *         server's own time.
                  */
                 idempotent omero::RTime getServerTime() throws ServerError;

--- a/src/main/slice/omero/api/IContainer.ice
+++ b/src/main/slice/omero/api/IContainer.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -45,7 +43,7 @@ module omero {
          * </p>
          * <p>
          * Most methods take such an <code>options</code> map which is built
-         * on the client-side using the {@link Parameters} class. The
+         * on the client-side using the {@link omero.sys.Parameters} class. The
          * currently supported options are:
          * <ul>
          * <li><b>annotator</b>(Integer): If key exists but value null,
@@ -351,7 +349,7 @@ module omero {
                  *      dataset.addProject(p);
                  * </code>
                  * then for each parent relationship a DataObject
-                 * {@link omero.model.ILink} is created.
+                 * {@link ome.model.ILink} is created.
                  *
                  * @param obj
                  *            IObject. Supported: Project, Dataset,
@@ -363,7 +361,7 @@ module omero {
 
                 /**
                  * Convenience method to save network calls. Loops over the
-                 * array of IObjects calling {@link #createDataObject}.
+                 * array of IObjects calling {@code createDataObject}.
                  *
                  * @param dataObjects
                  *            Array of Omero <code>IObjects</code>
@@ -387,7 +385,7 @@ module omero {
 
                 /**
                  * Convenience method for creating links. Functionality also
-                 * available from {@link #createDataObject}
+                 * available from {@code createDataObject}
                  *
                  * @param links Array of links to be created.
                  * @param options Parameters as above.
@@ -401,8 +399,8 @@ module omero {
                  * To link or unlink objects to the specified object, we
                  * should call the methods link or unlink. TODO Or do we use
                  * for example dataset.setProjects(set of projects) to add.
-                 * Tink has to be set as follows dataset->project and
-                 * project->dataset.
+                 * Link has to be set as follows dataset&rarr;project and
+                 * project&rarr;dataset.
                  *
                  * Alternatively, you can make sure that the collection is
                  * <b>exactly</b> how it should be in the database. If you
@@ -418,7 +416,7 @@ module omero {
 
                 /**
                  * Convenience method to save network calls. Loops over the
-                 * array of IObjects calling {@link #updateDataObject}.
+                 * array of IObjects calling {@code updateDataObject}.
                  *
                  * @param objs
                  * @param options

--- a/src/main/slice/omero/api/ILdap.ice
+++ b/src/main/slice/omero/api/ILdap.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010-2014 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/api/IMetadata.ice
+++ b/src/main/slice/omero/api/IMetadata.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010-2014 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -20,7 +18,7 @@ module omero {
         /**
          * Provides method to interact with acquisition metadata and
          * annotations.
-         **/
+         */
         ["ami", "amd"] interface IMetadata extends ServiceInterface
             {
                 /**
@@ -30,7 +28,7 @@ module omero {
                  * @param ids The collection of logical channel's ids.
                  * 		      Mustn't be <code>null</code>.
                  * @return The collection of loaded logical channels.
-                 **/
+                 */
                 idempotent LogicalChannelList loadChannelAcquisitionData(omero::sys::LongList ids) throws ServerError;
 
                 /**
@@ -52,7 +50,7 @@ module omero {
                  * @param rootIds
                  *      Ids of the objects of type <code>rootType</code>.
                  * 		Mustn't be <code>null</code>.
-                 * @param annotationType
+                 * @param annotationTypes
                  *      The types of annotation to retrieve. If
                  *      <code>null</code> all annotations will be loaded.
                  *      String of the type
@@ -65,7 +63,7 @@ module omero {
                  * @return A map whose key is rootId and value the
                  *         <code>Map</code> of all annotations for that node
                  *         or <code>null</code>.
-                 **/
+                 */
                 idempotent LongIObjectListMap loadAnnotations(string rootType, omero::sys::LongList rootIds,
                                                          omero::api::StringSet annotationTypes, omero::sys::LongList annotatorIds,
                                                          omero::sys::Parameters options) throws ServerError;
@@ -82,7 +80,7 @@ module omero {
                  *      Exclude the annotations with the specified name spaces.
                  * @param options   The POJO options.
                  * @return          A collection of found annotations.
-                 **/
+                 */
                 idempotent AnnotationList loadSpecifiedAnnotations(string annotationType,
                                                                    omero::api::StringSet include,
                                                                    omero::api::StringSet exclude,
@@ -98,7 +96,7 @@ module omero {
                  * @return Map whose key is a <code>Tag/TagSet</code> and the
                  *         value either a Map or a list of related
                  *         <code>DataObject</code>.
-                 **/
+                 */
                 idempotent LongIObjectListMap loadTagContent(omero::sys::LongList ids, omero::sys::Parameters options) throws ServerError;
 
                 /**
@@ -111,7 +109,7 @@ module omero {
                  *
                  * @param options The POJO options.
                  * @return See above.
-                 **/
+                 */
                 idempotent IObjectList loadTagSets(omero::sys::Parameters options) throws ServerError;
 
                 /**
@@ -121,7 +119,7 @@ module omero {
                  * @param ids The collection of ids.
                  * @param options The POJO options.
                  * @return See above.
-                 **/
+                 */
                 idempotent omero::sys::CountMap getTaggedObjectsCount(omero::sys::LongList ids, omero::sys::Parameters options) throws ServerError;
 
                 /**
@@ -134,7 +132,7 @@ module omero {
                  *                  constants defined by this class.
                  * @param options	The POJO options.
                  * @return See above.
-                 **/
+                 */
                 omero::RLong countSpecifiedAnnotations(string annotationType,
                                                        omero::api::StringSet include,
                                                        omero::api::StringSet exclude,
@@ -216,7 +214,7 @@ module omero {
                  * Finds the original file IDs for the import logs
                  * corresponding to the given Image or Fileset IDs.
                  *
-                 * @param rootNodeType
+                 * @param rootType
                  *       the root node type, may be {@link omero.model.Image}
                  *       or {@link omero.model.Fileset}
                  * @param ids

--- a/src/main/slice/omero/api/IPixels.ice
+++ b/src/main/slice/omero/api/IPixels.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -40,7 +38,7 @@ module omero {
                  *
                  * @param pixId Pixels id.
                  * @return Pixels object which matches <code>id</code>.
-                 **/
+                 */
                 idempotent omero::model::Pixels retrievePixDescription(long pixId) throws ServerError;
 
                 /**
@@ -80,7 +78,7 @@ module omero {
                  * </ul>
                  *
                  * @param pixId Pixels id.
-                 * @param userID  The id of the user.
+                 * @param userId  The id of the user.
                  * @return Rendering definition.
                  **/
                 idempotent omero::model::RenderingDef retrieveRndSettingsFor(long pixId, long userId) throws ServerError;
@@ -286,7 +284,7 @@ module omero {
                  *         <code>null</code> on failure.
                  * @throws ValidationException If the channel list is
                  *         <code>null</code> or of size == 0.
-                 **/
+                 */
                 omero::RLong createImage(int sizeX, int sizeY, int sizeZ, int sizeT,
                                          omero::sys::IntList channelList,
                                          omero::model::PixelsType pixelsType,
@@ -301,7 +299,7 @@ module omero {
                  * @param channelIndex The channel index within the Pixels set.
                  * @param min The channel global minimum.
                  * @param max The channel global maximum.
-                 **/
+                 */
                 void setChannelGlobalMinMax(long pixelsId, int channelIndex, double min, double max) throws ServerError;
             };
     };

--- a/src/main/slice/omero/api/IProjection.ice
+++ b/src/main/slice/omero/api/IProjection.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -63,12 +61,12 @@ module omero {
                  *   <li><code>channelIndex</code> is out of range</li>
                  *   <li><code>start</code> is out of range</li>
                  *   <li><code>end</code> is out of range</li>
-                 *   <li><code>start > end</code></li>
+                 *   <li><code>start</code> is greater than <code>end</code></li>
                  *   <li>the Pixels set qualified by <code>pixelsId</code> is
-                 *       unlocatable.</li>
+                 *       not locatable.</li>
                  * </ul>
                  * @see #projectPixels
-                 **/
+                 */
                 Ice::ByteSeq projectStack(long pixelsId,
                                           omero::model::PixelsType pixelsType,
                                           omero::constants::projection::ProjectionType algorithm,
@@ -80,7 +78,7 @@ module omero {
                  * optical sections for a given set of time points of a Pixels
                  * set. The Image which is linked to the Pixels set will be
                  * copied using
-                 * {@link omero.api.IPixels#copyAndResizeImage}.
+                 * {@code omero.api.IPixels.copyAndResizeImage}.
                  *
                  * @param pixelsId The source Pixels set Id.
                  * @param pixelsType The destination Pixels type. If
@@ -96,7 +94,7 @@ module omero {
                  *                  Pixels type.
                  * @param tStart Timepoint to start projecting from.
                  * @param tEnd Timepoint to finish projecting.
-                 * @param channels List of the channel indexes to use while
+                 * @param channelList List of the channel indexes to use while
                  *                 calculating the projection.
                  * @param stepping Stepping value to use while calculating the
                  *                 projection. For example,
@@ -124,17 +122,17 @@ module omero {
                  *   <li><code>algorithm</code> is unknown</li>
                  *   <li><code>tStart</code> is out of range</li>
                  *   <li><code>tEnd</code> is out of range</li>
-                 *   <li><code>tStart > tEnd</code></li>
-                 *   <li><code>channels</code> is null or has indexes out of
+                 *   <li><code>tStart</code> is greater than <code>tEnd</code></li>
+                 *   <li><code>channelList</code> is null or has indexes out of
                  *       range</li>
                  *   <li><code>zStart</code> is out of range</li>
                  *   <li><code>zEnd</code> is out of range</li>
-                 *   <li><code>zStart > zEnd</code></li>
+                 *   <li><code>zStart</code> is greater than <code>zEnd</code></li>
                  *   <li>the Pixels set qualified by <code>pixelsId</code> is
-                 *       unlocatable.</li>
+                 *       not locatable.</li>
                  * </ul>
                  * @see #projectStack
-                 **/
+                 */
                 long projectPixels(long pixelsId, omero::model::PixelsType pixelsType,
                                    omero::constants::projection::ProjectionType algorithm,
                                    int tStart, int tEnd,

--- a/src/main/slice/omero/api/IQuery.ice
+++ b/src/main/slice/omero/api/IQuery.ice
@@ -28,7 +28,7 @@ module omero {
          * never return a null or empty {@link java.util.Collection}, but
          * instead will throw a {@link omero.ValidationException}.
          *
-         **/
+         */
         ["ami", "amd"] interface IQuery extends ServiceInterface
             {
 
@@ -40,7 +40,7 @@ module omero {
                  * @param id the entity's id
                  * @return an initialized entity
                  * @throws ValidationException if the id doesn't exist.
-                 **/
+                 */
                 idempotent omero::model::IObject get(string klass, long id) throws ServerError;
 
 
@@ -51,7 +51,7 @@ module omero {
                  * @param klass klass the type of the entity. Not null.
                  * @param id the entity's id
                  * @return an initialized entity or null if id doesn't exist.
-                 **/
+                 */
                 idempotent omero::model::IObject find(string klass, long id) throws ServerError;
 
                 /**
@@ -62,8 +62,8 @@ module omero {
                  * @param filter filters the result set. Can be null.
                  * @return a collection if initialized entities or an empty
                  *         List if none exist.
-                 **/
-                idempotent IObjectList           findAll(string klass, omero::sys::Filter filter) throws ServerError;
+                 */
+                idempotent IObjectList findAll(string klass, omero::sys::Filter filter) throws ServerError;
 
                 /**
                  * Searches based on provided example entity. The example
@@ -71,13 +71,13 @@ module omero {
                  * exception will be thrown.
                  *
                  * Note: findByExample does not operate on the <code>id</code>
-                 * field. For that, use {@link #find}, {@link #get},
-                 * {@link #findByQuery}, or {@link #findAllByQuery}.
+                 * field. For that, use {@code find}, {@code get},
+                 * {@code findByQuery}, or {@code findAllByQuery}.
                  *
                  * @param example Non-null example object.
                  * @return Possibly null IObject result.
                  * @throws ApiUsageException if more than one result is return.
-                 **/
+                 */
                 idempotent omero::model::IObject findByExample(omero::model::IObject example) throws ServerError;
 
                 /**
@@ -87,15 +87,14 @@ module omero {
                  *
                  * Note: findAllbyExample does not operate on the
                  * <code>id</code> field.
-                 * For that, use {@link #find}, {@link #get},
-                 * {@link #findByQuery}, or {@link #findAllByQuery}
-                 *
+                 * For that, use {@code find}, {@code get},
+                 * {@code findByQuery}, or {@code findAllByQuery}.
                  *
                  * @param example Non-null example object.
                  * @param filter filters the result set. Can be null.
                  * @return Possibly empty List of IObject results.
-                 **/
-                idempotent IObjectList           findAllByExample(omero::model::IObject example, omero::sys::Filter filter) throws ServerError;
+                 */
+                idempotent IObjectList findAllByExample(omero::model::IObject example, omero::sys::Filter filter) throws ServerError;
 
                 /**
                  * Searches a given field matching against a String. Method
@@ -106,12 +105,12 @@ module omero {
                  * @param klass type of entity to be searched
                  * @param field the name of the field, either as simple string
                  *              or as public static final from the entity
-                 *              class, e.g. {@link omero.model.Project#NAME}
+                 *              class, e.g. {@code omero.model.Project.NAME}
                  * @param value String used for search.
                  * @return found entity or possibly null.
                  * @throws ome.conditions.ApiUsageException
                  *             if more than one result.
-                 **/
+                 */
                 idempotent omero::model::IObject findByString(string klass, string field, string value) throws ServerError;
 
                 /**
@@ -123,14 +122,14 @@ module omero {
                  * @param klass type of entity to be searched. Not null.
                  * @param field the name of the field, either as simple string
                  *              or as public static final from the entity
-                 *              class, e.g. {@link omero.model.Project#NAME}.
+                 *              class, e.g. {@code omero.model.Project.NAME}.
                  *              Not null.
                  * @param value String used for search. Not null.
                  * @param caseSensitive whether to use LIKE or ILIKE
                  * @param filter filters the result set. Can be null.
                  * @return A list (possibly empty) with the results.
-                 **/
-                idempotent IObjectList           findAllByString(string klass, string field, string value, bool caseSensitive, omero::sys::Filter filter) throws ServerError;
+                 */
+                idempotent IObjectList findAllByString(string klass, string field, string value, bool caseSensitive, omero::sys::Filter filter) throws ServerError;
 
                 /**
                  * Executes the stored query with the given name. If a query
@@ -144,7 +143,7 @@ module omero {
                  * @param params
                  * @return Possibly null IObject result.
                  * @throws ValidationException
-                 **/
+                 */
                 idempotent omero::model::IObject findByQuery(string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
@@ -182,7 +181,7 @@ module omero {
                  * @param params
                  * @return Possibly empty List of IObject results.
                  */
-                idempotent IObjectList           findAllByQuery(string query, omero::sys::Parameters params) throws ServerError;
+                idempotent IObjectList findAllByQuery(string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
                  * Executes a full text search based on Lucene. Each term in
@@ -214,7 +213,7 @@ module omero {
                  * @return A list of loaded {@link omero.model.IObject}
                  *         instances. Never null.
                  **/
-                idempotent IObjectList           findAllByFullText(string klass, string query, omero::sys::Parameters params) throws ServerError;
+                idempotent IObjectList findAllByFullText(string klass, string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
                  * Return a sequence of {@link omero.RType} sequences.
@@ -265,8 +264,8 @@ module omero {
                  * </pre>
                  * </p>
                  *
-                 **/
-                idempotent RTypeSeqSeq           projection(string query, omero::sys::Parameters params) throws ServerError;
+                 */
+                idempotent RTypeSeqSeq projection(string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
                  * Refreshes an entire {@link omero.model.IObject} graph,
@@ -283,7 +282,7 @@ module omero {
                  *         with the database.
                  * @throws ApiUsageException if any non-managed entities are
                  *         found.
-                 **/
+                 */
                 idempotent omero::model::IObject refresh(omero::model::IObject iObject) throws ServerError;
             };
 

--- a/src/main/slice/omero/api/IRenderingSettings.ice
+++ b/src/main/slice/omero/api/IRenderingSettings.ice
@@ -210,10 +210,10 @@ module omero {
                  * @param toType The type of nodes to handle.
                  * @param nodeIds Ids of the node type.
                  * @return A map with two boolean keys. The value of the key
-                 *         <code>TRUE</code> is a collection of images ID, the
+                 *         <code>TRUE</code> is a collection of image IDs, the
                  *         settings were successfully applied to.
                  *         The value of the key <code>FALSE</code> is a collection
-                 *         of images ID, the settings could not be applied to.
+                 *         of image IDs, the settings could not be applied to.
                  * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
                  */

--- a/src/main/slice/omero/api/IRenderingSettings.ice
+++ b/src/main/slice/omero/api/IRenderingSettings.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -66,7 +64,7 @@ module omero {
                  * good image (PG)</i> logic for the pixels set linked to that
                  * set of rendering settings. <b>NOTE:</b> This method should
                  * only be used to reset a rendering definition that has been
-                 * retrieved via {@link #getRenderingSettings} as it
+                 * retrieved via {@code getRenderingSettings} as it
                  * relies on certain objects being loaded. The rendering
                  * settings are saved upon completion.
                  *
@@ -84,7 +82,7 @@ module omero {
                  * good image (PG)</i> logic for the pixels set linked to that
                  * set of rendering settings. <b>NOTE:</b> This method should
                  * only be used to reset a rendering definition that has been
-                 * retrieved via {@link #getRenderingSettings(long)} as it
+                 * retrieved via {@code getRenderingSettings(long)} as it
                  * relies on certain objects being loaded. The rendering
                  * settings are not saved.
                  *
@@ -124,13 +122,13 @@ module omero {
                  * are specified by the rendering engine intelligent <i>pretty
                  * good image (PG)</i> logic.
                  *
-                 * @param dataSetId The Id of the Dataset.
+                 * @param datasetId The Id of the Dataset.
                  * @return A {@link java.util.Set} of image IDs that have had
                  *         their rendering settings reset.
                  * @throws ValidationException if the image qualified by
-                 * <code>dataSetId</code> is unlocatable.
+                 * <code>datasetId</code> is not locatable.
                  **/
-                omero::sys::LongList resetDefaultsInDataset(long dataSetId) throws ServerError;
+                omero::sys::LongList resetDefaultsInDataset(long datasetId) throws ServerError;
 
                 /**
                  * Resets a rendering settings back to one or many containers
@@ -166,7 +164,7 @@ module omero {
                  * </ul>
                  * @param type The type of nodes to handle.
                  * @param nodeIds Ids of the node type.
-                 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * @return A {@link java.util.Set} of image IDs that have
                  *         had their rendering settings reset.
                  * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
@@ -186,7 +184,7 @@ module omero {
                  * </ul>
                  * @param type The type of nodes to handle.
                  * @param nodeIds Ids of the node type.
-                 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * @return A {@link java.util.Set} of image IDs that have
                  *         had their rendering settings reset.
                  * @throws ValidationException if an illegal <code>type</code>
                  *         is used.
@@ -235,8 +233,8 @@ module omero {
                  *         The value of the <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
                  * @throws ValidationException if the rendering settings
-                 *         <code>from</code> is unlocatable or the project
-                 *         <code>to</code> is unlocatable.
+                 *         <code>from</code> is not locatable or the project
+                 *         <code>to</code> is not locatable.
                  */
                 BooleanIdListMap applySettingsToProject(long from, long to) throws ServerError;
 
@@ -253,8 +251,8 @@ module omero {
                  *         The value of the <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
                  * @throws ValidationException if the rendering settings
-                 *         <code>from</code> is unlocatable or the dataset
-                 *         <code>to</code> is unlocatable.
+                 *         <code>from</code> is not locatable or the dataset
+                 *         <code>to</code> is not locatable.
                  */
                 BooleanIdListMap applySettingsToDataset(long from, long to) throws ServerError;
 
@@ -268,8 +266,8 @@ module omero {
                  * @return <code>true</code> if the settings were successfully
                  *         applied, <code>false</code> otherwise.
                  * @throws ValidationException if the rendering settings
-                 *         <code>from</code> is unlocatable or the image
-                 *         <code>to</code> is unlocatable.
+                 *         <code>from</code> is not locatable or the image
+                 *         <code>to</code> is not locatable.
                  */
                 BooleanIdListMap applySettingsToImages(long from, omero::sys::LongList to) throws ServerError;
 
@@ -283,8 +281,8 @@ module omero {
                  * @return <code>true</code> if the settings were successfully
                  *         applied, <code>false</code> otherwise.
                  * @throws ValidationException if the rendering settings
-                 *         <code>from</code> is unlocatable or the image
-                 *         <code>to</code> is unlocatable.
+                 *         <code>from</code> is not locatable or the image
+                 *         <code>to</code> is not locatable.
                  */
                 bool applySettingsToImage(long from, long to) throws ServerError;
 
@@ -297,8 +295,8 @@ module omero {
                  *           to.
                  * @return See above.
                  * @throws ValidationException if the rendering settings
-                 *         <code>from</code> is unlocatable or the
-                 *         pixels<code>to</code> is unlocatable.
+                 *         <code>from</code> is not locatable or the
+                 *         pixels<code>to</code> is not locatable.
                  */
                 bool applySettingsToPixels(long from, long to) throws ServerError;
 
@@ -308,7 +306,7 @@ module omero {
                  *
                  * @param imageId The Id of the Image.
                  * @throws ValidationException if the image qualified by
-                 *         <code>imageId</code> is unlocatable.
+                 *         <code>imageId</code> is not locatable.
                  */
                 void setOriginalSettingsInImage(long imageId) throws ServerError;
 
@@ -318,7 +316,7 @@ module omero {
                  *
                  * @param pixelsId The Id of the Pixels set.
                  * @throws ValidationException if the image qualified by
-                 *         <code>pixelsId</code> is unlocatable.
+                 *         <code>pixelsId</code> is not locatable.
                  */
                 void setOriginalSettingsForPixels(long pixelsId) throws ServerError;
 
@@ -327,12 +325,12 @@ module omero {
                  * minimum and maximum.
                  *
                  * @param datasetId The id of the dataset to handle.
-                 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * @return A {@link java.util.Set} of image IDs that have
                  *         had their rendering settings reset.
                  * @throws ValidationException if the image qualified by
-                 *         <code>datasetId</code> is unlocatable.
+                 *         <code>datasetId</code> is not locatable.
                  */
-                omero::sys::LongList setOriginalSettingsInDataset(long dataSetId) throws ServerError;
+                omero::sys::LongList setOriginalSettingsInDataset(long datasetId) throws ServerError;
 
                 /**
                  * Resets a rendering settings back to channel global minimum
@@ -348,7 +346,7 @@ module omero {
                  *
                  * @param type The type of nodes to handle.
                  * @param nodeIds Ids of the node type.
-                 * @return A {@link omero.sys.LongList} of image IDs that have
+                 * @return A {@link java.util.Set} of image IDs that have
                  *         had their rendering settings reset.
                  * @throws ValidationException if an illegal <code>type</code>
                  *         is used.

--- a/src/main/slice/omero/api/IRenderingSettings.ice
+++ b/src/main/slice/omero/api/IRenderingSettings.ice
@@ -209,10 +209,10 @@ module omero {
                  *             settings from.
                  * @param toType The type of nodes to handle.
                  * @param nodeIds Ids of the node type.
-                 * @return A map with two boolean keys. The value of the
+                 * @return A map with two boolean keys. The value of the key
                  *         <code>TRUE</code> is a collection of images ID, the
                  *         settings were successfully applied to.
-                 *         The value of the <code>FALSE</code> is a collection
+                 *         The value of the key <code>FALSE</code> is a collection
                  *         of images ID, the settings could not be applied to.
                  * @throws ValidationException if an illegal <code>type</code>
                  *         is used.

--- a/src/main/slice/omero/api/IRepositoryInfo.ice
+++ b/src/main/slice/omero/api/IRepositoryInfo.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/api/IRoi.ice
+++ b/src/main/slice/omero/api/IRoi.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2009 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -23,7 +21,7 @@ module omero {
 
         /**
          * Specifies filters used when querying the ROIs.
-         **/
+         */
         class RoiOptions
             {
                 StringSet          shapes;
@@ -50,7 +48,7 @@ module omero {
          *
          * respectively.
          *
-         **/
+         */
         class RoiResult
             {
                 RoiOptions         opts;
@@ -69,7 +67,7 @@ module omero {
          * same size with each pair of entries representing a
          * single point in the 2D plane.
          *
-         **/
+         */
         class ShapePoints
             {
                 IntegerArray x;
@@ -84,7 +82,7 @@ module omero {
          * channels which compose this Shape. If the user specified no
          * logical channels for the Shape, then all logical channels from
          * the Pixels will be in channelIds.
-         **/
+         */
         class ShapeStats
             {
                 long         shapeId;
@@ -117,7 +115,7 @@ module omero {
 
         /**
          * Interface for working with regions of interest.
-         **/
+         */
         ["ami","amd"] interface IRoi extends ServiceInterface
             {
 
@@ -126,7 +124,7 @@ module omero {
                  * Shape linkages are properly created.
                  * All Shapes are loaded, as is the Pixels and Image object.
                  * TODO: Annotations?
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByRoi(long roiId, RoiOptions opts) throws omero::ServerError;
@@ -135,7 +133,7 @@ module omero {
                  * Returns all the Rois in an Image, indexed via Shape.
                  *
                  * Loads Rois as findByRoi.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByImage(long imageId, RoiOptions opts) throws omero::ServerError;
@@ -144,35 +142,35 @@ module omero {
                  * Returns all the Rois on the given plane, indexed via Shape.
                  *
                  * Loads Rois as findByRoi.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult findByPlane(long imageId, int z, int t, RoiOptions opts) throws omero::ServerError;
 
                 /**
                  * Calculate the points contained within a given shape
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapePoints getPoints(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate stats for all the shapes within the given Roi.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiStats getRoiStats(long roiId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shape.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStats getShapeStats(long shapeId) throws omero::ServerError;
 
                 /**
                  * Calculate the stats for the points within the given Shapes.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStatsList getShapeStatsList(LongList shapeIdList) throws omero::ServerError;
@@ -186,7 +184,7 @@ module omero {
                  *   that is to say there is never more than 1 z/t combination queried
                  * - if channel list is given, only the channels in that list are iterated over
                  * - does not request data from reader on each iteration 
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 ShapeStatsList getShapeStatsRestricted(
@@ -206,7 +204,7 @@ module omero {
                  *
                  * @param opts, userId and groupId are respected based on the
                  *        ownership of the annotation.
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 AnnotationList getRoiMeasurements(long imageId, RoiOptions opts) throws omero::ServerError;
@@ -216,7 +214,7 @@ module omero {
                  * {@link omero.model.FileAnnotation} id for the given image.
                  *
                  * @param annotationId if -1, logic is identical to findByImage(imageId, opts)
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 RoiResult getMeasuredRois(long imageId, long annotationId, RoiOptions opts) throws omero::ServerError;
@@ -226,7 +224,7 @@ module omero {
                  * to {@link RoiResult} instances.
                  * Logic is identical to getMeasuredRois, but Roi data will not be duplicated. (i.e.
                  * the objects are referentially identical)
-                 **/
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 LongRoiResultMap getMeasuredRoisMap(long imageId, LongList annotationIds, RoiOptions opts) throws omero::ServerError;
@@ -234,8 +232,8 @@ module omero {
                 /**
                  * Returns the OMERO.tables service via the
                  * {@link omero.model.FileAnnotation} id returned
-                 * by {@link #getImageMeasurements}.
-                 **/
+                 * by {@code getImageMeasurements}.
+                 */
                 ["deprecate:IROI is deprecated."]
                 idempotent
                 omero::grid::Table* getTable(long annotationId) throws omero::ServerError;

--- a/src/main/slice/omero/api/IScript.ice
+++ b/src/main/slice/omero/api/IScript.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -21,7 +19,7 @@ module omero {
          *
          * Typical usage might include (PYTHON):
          * <pre>
-         *
+         * {@code
          * sf = client.createSession()
          * svc = sf.getScriptService()
          * scripts = svc.getScripts()
@@ -46,7 +44,7 @@ module omero {
          *     rv = proc.getResults(0)
          * finally:
          *     proc.close(False)
-         *
+         * }
          * </pre>
          * See <a href="https://docs.openmicroscopy.org/latest/omero/developers/scripts/">OMERO.scripts</a> for more information.
          **/
@@ -61,9 +59,9 @@ module omero {
                  * This method returns official server scripts as a list of
                  * {@link omero.model.OriginalFile} objects.
                  * These scripts will be executed by the server if submitted
-                 * via {@link #runScript}. The input parameters
+                 * via {@code runScript}. The input parameters
                  * necessary for proper functioning can be retrieved via
-                 * {@link #getParams}.
+                 * {@code getParams}.
                  *
                  * The {@link omero.model.OriginalFile#path} value can be used
                  * in other official scripts via the
@@ -71,6 +69,7 @@ module omero {
                  * directory will be placed on the appropriate
                  * environment path variable.
                  * <pre>
+                 * {@code
                  * scripts = scriptService.getScripts()
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
@@ -78,12 +77,13 @@ module omero {
                  *     path = script.path.val\[1:\]
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
+                 * }
                  * </pre>
                  *
                  * @return see above.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 idempotent OriginalFileList getScripts() throws ServerError;
 
                 /**
@@ -91,9 +91,9 @@ module omero {
                  * with the specified extension as a list of
                  * {@link omero.model.OriginalFile} objects.
                  * These scripts will be executed by the server if submitted
-                 * via {@link #runScript}. The input parameters
+                 * via {@code runScript}. The input parameters
                  * necessary for proper functioning can be retrieved via
-                 * {@link #getParams}.
+                 * {@code getParams}.
                  *
                  * The {@link omero.model.OriginalFile#path} value can be used
                  * in other official scripts via the
@@ -101,19 +101,21 @@ module omero {
                  * directory will be placed on the appropriate
                  * environment path variable.
                  * <pre>
+                 * {@code
                  * scripts = scriptService.getScripts("py")
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
                  *     path = script.path.val\[1:\] # First symbol is a "/"
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
+                 * }
                  * </pre>
                  *
                  * @param mimetype the mimetype identifying the scripts.
                  * @return see above.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 idempotent OriginalFileList getScriptsByMimetype(string mimetype) throws ServerError;
 
                 /**
@@ -128,14 +130,14 @@ module omero {
                  * Get the id of an official script by the script path.
                  * The script service ensures that all script paths are unique.
                  *
-                 * Note: there is no similar method for user scripts (e.g. getUserScriptID)
+                 * Note: there is no similar method for user scripts (e.g. {@code getUserScriptID})
                  * since the path is not guaranteed to be unique.
                  *
-                 * @param scriptName The name of the script.
+                 * @param path The name of the script.
                  * @return see above.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 idempotent long getScriptID(string path) throws  ServerError;
 
                 /**
@@ -144,7 +146,7 @@ module omero {
                  * @param scriptID see above.
                  * @return see above.
                  * @throws ApiUsageException
-                 **/
+                 */
                 idempotent string getScriptText(long scriptID) throws ServerError;
 
                 /**
@@ -153,15 +155,16 @@ module omero {
                  * <em>if possible</em>, i.e. a usermode processor is running which for the
                  * current user.
                  *
-                 * @param script see above.
+                 * @param path see above.
+                 * @param scriptText see above.
                  * @return The new id of the script.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 long uploadScript(string path, string scriptText) throws ServerError;
 
                 /**
-                 * Like {@link #uploadScript} but is only callable by
+                 * Like {@code uploadScript} but is only callable by
                  * administrators. The parameters for the script are also
                  * checked.
                  **/
@@ -170,10 +173,11 @@ module omero {
                 /**
                  * Modify the text for the given script object.
                  *
-                 * @param script see above.
+                 * @param fileObject see above.
+                 * @param scriptText see above.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 void editScript(omero::model::OriginalFile fileObject, string scriptText) throws ServerError;
 
                 /**
@@ -181,7 +185,7 @@ module omero {
                  * @param scriptID see above
                  * @return see above
                  * @throws ApiUsageException
-                 **/
+                 */
                 idempotent RTypeDict getScriptWithDetails(long scriptID) throws ServerError;
 
                 /**
@@ -200,7 +204,7 @@ module omero {
                  * @param scriptID Id of the script to delete.
                  * @throws ApiUsageException
                  * @throws SecurityViolation
-                 **/
+                 */
                 void deleteScript(long scriptID) throws ServerError;
 
                 // Planned methods
@@ -214,31 +218,35 @@ module omero {
                 //
 
                 /**
-                 * If {@link ResourceError} is thrown, then no
-                 * {@link Processor} is available. Use {@link #scheduleJob}
+                 * If {@link omero.ResourceError} is thrown, then no
+                 * {@code Processor} is available. Use {@code scheduleJob}
                  * to create a {@link omero.model.ScriptJob} in the
-                 * <i>Waiting</i> state. A {@link Processor} may become
+                 * <i>Waiting</i> state. A {@code Processor} may become
                  * available.
                  *
                  * <pre>
+                 * {@code
                  * try:
                  *     proc = scriptService.runScript(1, {}, None)
                  * except ResourceError:
                  *     job = scriptService.scheduleScript(1, {}, None)
+                 * }
                  * </pre>
                  *
-                 * The {@link ScriptProcess} proxy MUST be closed before
+                 * The {@code ScriptProcess} proxy MUST be closed before
                  * exiting. If you would like the script execution to continue
                  * in the background, pass <code>True</code> as the argument.
                  *
                  * <pre>
+                 * {@code
                  * try:
                  *     proc.poll()         # See if process is finished
                  * finally:
                  *     proc.close(True)    # Detach and execution can continue
                  *     # proc.close(False) # OR script is immediately stopped.
+                 * }
                  * </pre>
-                 **/
+                 */
                 omero::grid::ScriptProcess* runScript(long scriptID, omero::RTypeDict inputs, omero::RInt waitSecs) throws ServerError;
 
                 /**
@@ -253,14 +261,14 @@ module omero {
                  * must be active which takes the scripts user or group.
                  * </p>
                  *
-                 **/
+                 */
                 idempotent
                 bool canRunScript(long scriptID) throws ServerError;
 
                 /**
                  * Used internally by processor.py to check if the script
                  * attached to the {@link omero.model.Job} has a valid script
-                 * attached, based on the {@link #acceptsList} and the current
+                 * attached, based on the {@code acceptsList} and the current
                  * security context.
                  *
                  * An example of an acceptsList might be <pre>Experimenter(myUserId, False)</pre>, meaning that
@@ -268,7 +276,7 @@ module omero {
                  * return what it would by default trust.
                  *
                  * A valid script will be returned if it exists; otherwise null.
-                 **/
+                 */
                 idempotent
                 omero::model::OriginalFile validateScript(omero::model::Job j, omero::api::IObjectList acceptsList) throws ServerError;
 

--- a/src/main/slice/omero/api/ISession.ice
+++ b/src/main/slice/omero/api/ISession.ice
@@ -20,7 +20,7 @@ module omero {
          * all other services is dependent upon a properly created and still
          * active {@link omero.model.Session}.
          *
-         * The session uuid ({@link omero.model.Session#getUuid}) can be
+         * The session uuid ({@code omero.model.Session.getUuid}) can be
          * considered a capability token, or temporary single use password.
          * Simply by possessing it the client has access to all information
          * available to the {@link omero.model.Session}.
@@ -57,14 +57,14 @@ module omero {
                 //
 
                 /**
-                 * Allows an admin to create a {@link Session} for the give
+                 * Allows an admin to create a {@link ome.model.meta.Session} for the give
                  * {@link omero.sys.Principal}.
                  *
                  * @param principal
                  *            Non-null {@link omero.sys.Principal} with the
                  *            target user's name
                  * @param timeToLiveMilliseconds
-                 *            The time that this {@link omero.model.Session}
+                 *            The time that this {@link ome.model.meta.Session}
                  *            has until destruction. This is useful to
                  *            override the server default so that an initial
                  *            delay before the user is given the token will
@@ -72,43 +72,43 @@ module omero {
                  *            1 will cause the default max timeToLive to be
                  *            used; but timeToIdle will be disabled.
                  */
-                omero::model::Session createSessionWithTimeout(omero::sys::Principal p, long timeToLiveMilliseconds)
+                omero::model::Session createSessionWithTimeout(omero::sys::Principal principal, long timeToLiveMilliseconds)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
                 /**
-                 * Allows an admin to create a {@link omero.model.Session} for
+                 * Allows an admin to create a {@link ome.model.meta.Session} for
                  * the given {@link omero.sys.Principal}.
                  *
                  * @param principal
                  *            Non-null {@link omero.sys.Principal} with the
                  *            target user's name
                  * @param timeToLiveMilliseconds
-                 *            The time that this {@link omero.model.Session}
+                 *            The time that this {@link ome.model.meta.Session}
                  *            has until destruction. Setting the value to 0
                  *            will prevent destruction unless the session
                  *            remains idle.
                  * @param timeToIdleMilliseconds
-                 *            The time that this {@link omero.model.Session}
+                 *            The time that this {@link ome.model.meta.Session}
                  *            can remain idle before being destroyed. Setting
                  *            the value to 0 will prevent idleness based
                  *            destruction.
                  */
-                omero::model::Session createSessionWithTimeouts(omero::sys::Principal p, long timeToLiveMilliseconds, long timeToIdleMilliseconds)
+                omero::model::Session createSessionWithTimeouts(omero::sys::Principal principal, long timeToLiveMilliseconds, long timeToIdleMilliseconds)
                 throws ServerError, Glacier2::CannotCreateSessionException;
 
                 /**
                  * Retrieves the session associated with this uuid, updating
                  * the last access time as well. Throws a
-                 * {@link RemovedSessionException} if not present, or
-                 * a {@link SessionTimeoutException} if expired.
+                 * {@link omero.RemovedSessionException} if not present, or
+                 * a {@link omero.SessionTimeoutException} if expired.
                  *
-                 * This method can be used as a {@link Session} ping.
+                 * This method can be used as a {@link ome.model.meta.Session} ping.
                  */
                 idempotent omero::model::Session getSession(string sessionUuid) throws ServerError;
 
                 /**
                  * Retrieves the current reference count for the given uuid.
-                 * Has the same semantics as {@link #getSession}.
+                 * Has the same semantics as {@code getSession}.
                  */
                 idempotent int getReferenceCount(string sessionUuid) throws ServerError;
 
@@ -133,13 +133,13 @@ module omero {
                 idempotent SessionList getMyOpenSessions() throws ServerError;
 
                 /**
-                 * Like {@link #getMyOpenSessions} but returns only those
+                 * Like {@code getMyOpenSessions} but returns only those
                  * sessions with the given agent string.
                  */
                 idempotent SessionList getMyOpenAgentSessions(string agent) throws ServerError;
 
                 /**
-                 * Like {@link #getMyOpenSessions} but returns only those
+                 * Like {@code getMyOpenSessions} but returns only those
                  * sessions started by official OMERO clients.
                  */
                 idempotent SessionList getMyOpenClientSessions() throws ServerError;
@@ -175,7 +175,7 @@ module omero {
                  * Retrieves all keys in the {@link omero.model.Session} input
                  * environment.
                  *
-                 * @return a {@link StringSet} of keys
+                 * @return a {@link java.util.Set} of keys
                  */
                 idempotent StringSet getInputKeys(string sess) throws ServerError;
 

--- a/src/main/slice/omero/api/IShare.ice
+++ b/src/main/slice/omero/api/IShare.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -29,7 +27,7 @@ module omero {
                  * the execution of the current session for all database
                  * reads. Writing to the database will not be allowed. If
                  * share does not exist or is not accessible (non-members) or
-                 * is disabled, then an {@link ValidationException} is thrown.
+                 * is disabled, then an {@link omero.ValidationException} is thrown.
                  */
                 idempotent void activate(long shareId) throws ServerError;
 
@@ -72,11 +70,11 @@ module omero {
                  * Gets all owned shares for the current
                  * {@link omero.model.Experimenter}.
                  *
-                 * @param onlyActive
+                 * @param active
                  *            if true, then only shares which can be used for
                  *            login will be returned. All <i>draft</i> shares
-                 *            (see {@link #createShare}) and closed shares (see
-                 *            {@link #closeShare}) will be filtered.
+                 *            (see {@code createShare}) and closed shares (see
+                 *            {@code closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
                 idempotent SessionList getOwnShares(bool active) throws ServerError;
@@ -85,11 +83,11 @@ module omero {
                  * Gets all shares where current
                  * {@link omero.model.Experimenter} is a member.
                  *
-                 * @param onlyActive
+                 * @param active
                  *            if true, then only shares which can be used for
                  *            login will be returned. All <i>draft</i> shares
-                 *            (see {@link #createShare}) and closed shares (see
-                 *            {@link #closeShare}) will be filtered.
+                 *            (see {@code createShare}) and closed shares (see
+                 *            {@code closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
                 idempotent SessionList getMemberShares(bool active) throws ServerError;
@@ -98,11 +96,13 @@ module omero {
                  * Gets all shares owned by the given
                  * {@link omero.model.Experimenter}.
                  *
-                 * @param onlyActive
+                 * @param user
+                 *            the experimenter
+                 * @param active
                  *            if true, then only shares which can be used for
                  *            login will be returned. All <i>draft</i> shares
-                 *            (see {@link #createShare}) and closed shares (see
-                 *            {@link #closeShare}) will be filtered.
+                 *            (see {@code createShare}) and closed shares (see
+                 *            {@code closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
                 idempotent SessionList getSharesOwnedBy(omero::model::Experimenter user, bool active) throws ServerError;
@@ -111,11 +111,13 @@ module omero {
                  * Gets all shares where given
                  * {@link omero.model.Experimenter} is a member.
                  *
-                 * @param onlyActive
+                 * @param user
+                 *            the experimenter
+                 * @param active
                  *            if true, then only shares which can be used for
                  *            login will be returned. All <i>draft</i> shares
-                 *            (see {@link #createShare}) and closed shares (see
-                 *            {@link #closeShare}) will be filtered.
+                 *            (see {@code createShare}) and closed shares (see
+                 *            {@code closeShare}) will be filtered.
                  * @return set of shares. Never null. May be empty.
                  */
                 idempotent SessionList getMemberSharesFor(omero::model::Experimenter user, bool active) throws ServerError;
@@ -154,7 +156,7 @@ module omero {
                  *            if true, then the share is immediately available
                  *            for use. If false, then the share is in draft
                  *            state. All methods on this interface will work
-                 *            for shares <em>except</em> {@link #activate}.
+                 *            for shares <em>except</em> {@code activate}.
                  *            Similarly, the share password cannot be used by
                  *            guests to login.
                  */
@@ -171,7 +173,7 @@ module omero {
                 /**
                  * Closes {@link omero.model.Session} share. No further logins
                  * will be possible and all getters (e.g.
-                 * {@link #getMemberShares}, {@link #getOwnShares}, ...) will
+                 * {@code getMemberShares}, {@code getOwnShares}, ...) will
                  * filter these results if {@code onlyActive} is true.
                  */
                 void closeShare(long shareId) throws ServerError;
@@ -179,7 +181,7 @@ module omero {
                 /**
                  * Adds new {@link omero.model.IObject} items to
                  * {@link omero.model.Session} share. Conceptually calls
-                 * {@link #addObjects} for every argument passed, but the
+                 * {@code addObjects} for every argument passed, but the
                  * graphs will be merged.
                  */
                 void addObjects(long shareId, IObjectList iobjects) throws ServerError;
@@ -256,11 +258,11 @@ module omero {
 
                 /**
                  * Get a single set containing the
-                 * {@link omero.model.Experimenter#getOmeName} login names
+                 * {@code omero.model.Experimenter.getOmeName} login names
                  * of the users as well email addresses for guests.
                  *
                  * @param shareId
-                 * @return a {@link StringSet} containing the login of all
+                 * @return a {@link java.util.Set} containing the login of all
                  *         users
                  * @throws ValidationException
                  *         if there is a conflict between email addresses and

--- a/src/main/slice/omero/api/ITimeline.ice
+++ b/src/main/slice/omero/api/ITimeline.ice
@@ -67,10 +67,12 @@ module omero {
          *
          * A typical invocation might look like (in Python):
          * <pre>
+         * {@code
          *     timeline = sf.getTimelineService()
          *     params = ParametersI().page(0,100)
          *     types = \["Project","Dataset"])
          *     map = timeline.getByPeriod(types, params, False)
+         * }
          * </pre>
          * At this point, map will not contain more than 200 objects.
          *
@@ -78,7 +80,7 @@ module omero {
          * in the ome.api package.
          *
          * TODOS: binning, stateful caching, ...
-         **/
+         */
         ["ami", "amd"] interface ITimeline extends ServiceInterface {
 
             /**
@@ -94,7 +96,7 @@ module omero {
              * AND'ed to the query to filter results.
              *
              * Merges by default based on parentType.
-             **/
+             */
             idempotent
             IObjectList
                 getMostRecentAnnotationLinks(StringSet parentTypes, StringSet childTypes,
@@ -107,7 +109,7 @@ module omero {
              *
              * Note: Currently the storage of these objects is not optimal
              * and so this method may change.
-             **/
+             */
             idempotent
             IObjectList
                 getMostRecentShareCommentLinks(omero::sys::Parameters p)
@@ -116,7 +118,7 @@ module omero {
             /**
              * Returns the last LIMIT objects of TYPES as ordered by
              * creation/modification times in the Event table.
-             **/
+             */
             idempotent
             IObjectListMap
                 getMostRecentObjects(StringSet types, omero::sys::Parameters p, bool merge)
@@ -126,7 +128,7 @@ module omero {
              * Returns the given LIMIT objects of TYPES as ordered by
              * creation/modification times in the Event table, but
              * within the given time window.
-             **/
+             */
             idempotent
             IObjectListMap
                 getByPeriod(StringSet types, omero::RTime start, omero::RTime end, omero::sys::Parameters p,  bool merge)
@@ -135,7 +137,7 @@ module omero {
             /**
              * Queries the same information as getByPeriod, but only returns the counts
              * for the given objects.
-             **/
+             */
             idempotent
             StringLongMap
                 countByPeriod(StringSet types, omero::RTime start, omero::RTime end, omero::sys::Parameters p)
@@ -147,7 +149,7 @@ module omero {
              *
              * WORKAROUND WARNING: this method returns non-managed EventLogs (i.e.
              * eventLog.getId() == null) for <i>Image acquisitions</i>.
-             **/
+             */
             idempotent
             EventLogList
                 getEventLogsByPeriod(omero::RTime start, omero::RTime end, omero::sys::Parameters p)

--- a/src/main/slice/omero/api/ITypes.ice
+++ b/src/main/slice/omero/api/ITypes.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -21,7 +19,7 @@ module omero {
         /**
          * Access to reflective type information. Also provides simplified
          * access to special types like enumerations.
-         **/
+         */
         ["ami", "amd"] interface ITypes extends ServiceInterface
             {
                 omero::model::IObject createEnumeration(omero::model::IObject newEnum) throws ServerError;
@@ -36,7 +34,7 @@ module omero {
                  *              found.
                  * @return A managed enumeration. Never null.
                  * @throws ApiUsageException
-                 *         if {@link omero.model.IEnum} is not found.
+                 *         if {@link ome.model.IEnum} is not found.
                  */
                 idempotent omero::model::IObject getEnumeration(string type, string value) throws ServerError;
                 idempotent IObjectList allEnumerations(string type) throws ServerError;
@@ -76,11 +74,11 @@ module omero {
 
                 /**
                  * Returns a list of classes which implement
-                 * {@link omero.model.IAnnotated}. These can
+                 * {@link ome.model.IAnnotated}. These can
                  * be used in combination with {@link omero.api.Search}.
                  *
-                 * @return a {@link StringSet} of
-                 *         {@link omero.model.IAnnotated} implementations
+                 * @return a {@link java.util.Set} of
+                 *         {@link ome.model.IAnnotated} implementations
                  */
                 idempotent StringSet getAnnotationTypes() throws ServerError;
 
@@ -89,7 +87,7 @@ module omero {
                  * contained objects.
                  *
                  * @return map of classes that extend IEnum
-                 * @throws RuntimeExceptionif xml parsing failure.
+                 * @throws RuntimeException if xml parsing failure.
                  */
                 idempotent IObjectListMap getEnumerationsWithEntries() throws ServerError;
 

--- a/src/main/slice/omero/api/IUpdate.ice
+++ b/src/main/slice/omero/api/IUpdate.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -32,7 +30,7 @@ module omero {
          * The original objects <b>should be discarded</b>.
          * </p>
          *
-         * <p>{@link #saveAndReturnIds} behaves slightly differently in that
+         * <p>{@code saveAndReturnIds} behaves slightly differently in that
          * it does <em>not</em> handle object modifications. The graph of
          * objects passed in can consist <em>ONLY</em> if either newly created
          * objects without ids or of unloaded objects with ids. <em>Note:</em>
@@ -47,7 +45,7 @@ module omero {
          * objects do not pass validation, and
          * {@link omero.OptimisticLockException} if the version of a given has
          * already been incremented.
-         **/
+         */
         ["ami", "amd"] interface IUpdate extends ServiceInterface
             {
                 void saveObject(omero::model::IObject obj) throws ServerError;
@@ -67,7 +65,7 @@ module omero {
                  * the background {@link Thread} to complete.
                  *
                  * @param row
-                 *            a persistent {@link IObject} to be deleted
+                 *            a persistent {@link omero.model.IObject} to be deleted
                  * @throws ValidationException
                  *             if the object does not exist or is nul
                  */

--- a/src/main/slice/omero/api/JobHandle.ice
+++ b/src/main/slice/omero/api/JobHandle.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -22,14 +20,14 @@ module omero {
          * <p>
          * NOTE: The calling order for the service is as follows:
          * <ol>
-         * <li>{@link #submit} <em>or</em> {@link #attach}</li>
+         * <li>{@code submit} <em>or</em> {@code attach}</li>
          * <li>any of the other methods</li>
-         * <li>{@link #close}</li>
+         * <li>{@code close}</li>
          * </ol>
          * </p>
-         * Calling {@link #close} does not cancel or otherwise change
-         * the Job state. See {@link #cancelJob}.
-         **/
+         * Calling {@code close} does not cancel or otherwise change
+         * the Job state. See {@code cancelJob}.
+         */
         ["ami", "amd"] interface JobHandle extends StatefulServiceInterface
             {
                 /**
@@ -40,14 +38,14 @@ module omero {
                  *
                  * @param job Not null
                  */
-                long submit(omero::model::Job j) throws ServerError;
+                long submit(omero::model::Job job) throws ServerError;
 
                 /**
                  * Returns the current {@link omero.model.JobStatus} for the
                  * Job id.
                  *
                  * @throws ApiUsageException
-                 *             if the {@link Job id} does not exist.
+                 *             if the {@link omero.model.Job} does not exist.
                  */
                 omero::model::JobStatus attach(long jobId) throws ServerError;
 
@@ -97,8 +95,8 @@ module omero {
                 /**
                  * Updates the {@link omero.model.JobStatus} for the current
                  * job. The previous status is returned as a string. If the
-                 * status is {@link #CANCELLED}, this method is equivalent to
-                 * {@link #cancelJob}.
+                 * status is {@code CANCELLED}, this method is equivalent to
+                 * {@code cancelJob}.
                  */
                 idempotent string setStatus(string status) throws ServerError;
 
@@ -111,7 +109,7 @@ module omero {
                 idempotent string setMessage(string message) throws ServerError;
 
                 /**
-                 * Like {@link #setStatus} but also sets the message.
+                 * Like {@code setStatus} but also sets the message.
                  */
                 idempotent string setStatusAndMessage(string status, omero::RString message) throws ServerError;
             };

--- a/src/main/slice/omero/api/MetadataStore.ice
+++ b/src/main/slice/omero/api/MetadataStore.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2008 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -25,13 +23,13 @@ module omero {
 
     /**
      * Types used during import.
-     **/
+     */
     module metadatastore {
 
         /**
          * Container-class used by the import mechanism. Passed to
          * {@link omero.api.MetadataStore}
-         **/
+         */
         class IObjectContainer {
             string LSID;
             omero::api::StringIntMap indexes;
@@ -46,7 +44,7 @@ module omero {
 
         /**
          * Server-side interface for import.
-         **/
+         */
         ["ami","amd"] interface MetadataStore extends StatefulServiceInterface
             {
                 void createRoot() throws ServerError;

--- a/src/main/slice/omero/api/PyramidService.ice
+++ b/src/main/slice/omero/api/PyramidService.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -25,7 +23,7 @@ module omero {
          * Initially this contains simply the sizeX/sizeY so that the
          * client can calculate percentages. Eventually, this may also
          * include columns, rows, etc.
-         **/
+         */
         sequence<ResolutionDescription> ResolutionDescriptions;
 
         ["ami", "amd"]
@@ -36,7 +34,7 @@ module omero {
                  * pixels pyramid to provide sub-resolutions of the data.
                  * @return <code>true</code> if the pixels store requires a
                  * pixels pyramid and <code>false</code> otherwise.
-                 **/
+                 */
                 idempotent bool requiresPixelsPyramid() throws ServerError;
 
                 /**
@@ -45,27 +43,27 @@ module omero {
                  * @return The number of resolution levels. This value does not
                  * necessarily indicate either the presence or absence of a
                  * pixels pyramid.
-                 **/
+                 */
                 idempotent int getResolutionLevels() throws ServerError;
 
                 /**
                  * Retrieves a more complete definition of the resolution
                  * level in question. The size of this array will be of
-                 * length {@link #getResolutionLevels}.
-                 **/
+                 * length {@code getResolutionLevels}.
+                 */
                 idempotent ResolutionDescriptions getResolutionDescriptions() throws ServerError;
 
                 /**
                  * Retrieves the active resolution level.
                  * @return The active resolution level.
-                 **/
+                 */
                 idempotent int getResolutionLevel() throws ServerError;
 
                 /**
                  * Sets the active resolution level.
                  * @param resolutionLevel The resolution level to be used by
                  * the pixel buffer.
-                 **/
+                 */
                 idempotent void setResolutionLevel(int resolutionLevel) throws ServerError;
 
                 /**
@@ -73,7 +71,7 @@ module omero {
                  * @return An array of <code>length = 2</code> where the first
                  * value of the array is the tile width and the second value is
                  * the tile height.
-                 **/
+                 */
                 idempotent Ice::IntSeq getTileSize() throws ServerError;
 
             };

--- a/src/main/slice/omero/api/RawFileStore.ice
+++ b/src/main/slice/omero/api/RawFileStore.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -22,7 +20,7 @@ module omero {
          *
          * Note: methods on this service are protected by a <i>DOWNLOAD</i>
          * restriction.
-         **/
+         */
         ["ami", "amd"] interface RawFileStore extends StatefulServiceInterface
             {
 
@@ -30,7 +28,7 @@ module omero {
                  * This method manages the state of the service. This method
                  * will throw a {@link omero.SecurityViolation} if for the
                  * current user context either the file is not readable or a
-                 * {@link omero.constants.permissions#DOWNLOAD} restriction is
+                 * {@code omero.constants.permissions.BINARYACCESS} restriction is
                  * in place.
                  */
                 void setFileId(long fileId) throws ServerError;
@@ -50,7 +48,7 @@ module omero {
                 /**
                  * Returns the size of the file on disk (not as stored in the
                  * database since that value will only be updated on
-                 * {@link #save}. If the file has not yet been written to, and
+                 * {@code save}. If the file has not yet been written to, and
                  * therefore does not exist, a {@link omero.ResourceError}
                  * will be thrown.
                  */
@@ -91,7 +89,7 @@ module omero {
                  *
                  * If save has not been called, {@link omero.api.RawFileStore}
                  * instances will save the {@link omero.model.OriginalFile}
-                 * object associated with it on {@link #close}.
+                 * object associated with it on {@code close}.
                  *
                  * See also <a href="https://trac.openmicroscopy.org/ome/ticket/1651">ticket 1651</a>
                  * and <a href="https://trac.openmicroscopy.org/ome/ticket/2161">ticket 2161</a>.

--- a/src/main/slice/omero/api/RawPixelsStore.ice
+++ b/src/main/slice/omero/api/RawPixelsStore.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -24,8 +22,8 @@ module omero {
          * various slices, stacks, regions of the 5-dimensional (X-Y planes with
          * multiple Z-sections and Channels over Time). The byte array returned
          * by the getter methods and passed to the setter methods can and will
-         * be interpreted according to results of {@link #getByteWidth},
-         * {@link #isFloat}, and {@link #isSigned}.
+         * be interpreted according to results of {@code getByteWidth},
+         * {@code isFloat}, and {@code isSigned}.
          *
          * <p>
          * <b>Read-only caveat</b>:
@@ -36,7 +34,7 @@ module omero {
          * read-only. If Pixels data writing fails and the service is
          * inadvertently closed, delete the Pixels object, and create a new
          * one. Any partially written data will be removed.
-         **/
+         */
         ["ami", "amd"] interface RawPixelsStore extends PyramidService
             {
 
@@ -53,19 +51,19 @@ module omero {
                  *        <code>false</code> is expected.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 void setPixelsId(long pixelsId, bool bypassOriginalFile) throws ServerError;
 
                 /**
                  * Returns the current Pixels set identifier.
                  * @return See above.
-                 **/
+                 */
                 idempotent long getPixelsId() throws ServerError;
 
                 /**
                  * Returns the current Pixels path.
                  * @return See above.
-                 **/
+                 */
                 idempotent string getPixelsPath() throws ServerError;
 
                 /**
@@ -77,7 +75,7 @@ module omero {
                  * result in the existing cache being overwritten.
                  *
                  * @param pixelsIds Pixels IDs to cache.
-                 **/
+                 */
                 idempotent void prepare(omero::sys::LongList pixelsIds) throws ServerError;
 
                 /**
@@ -85,15 +83,15 @@ module omero {
                  * pixel store.
                  * @return 2D image plane size in bytes
                  *            <code>sizeX*sizeY*byteWidth</code>.
-                 **/
+                 */
                 idempotent long getPlaneSize() throws ServerError;
 
                 /**
                  * Retrieves the in memory size of a row or scanline of pixels
                  * in this pixel store.
                  * @return row or scanline size in bytes
-                 *         <codesizeX*byteWidth</code>
-                 **/
+                 *         <code>sizeX*byteWidth</code>
+                 */
                 idempotent int getRowSize() throws ServerError;
 
                 /**
@@ -103,7 +101,7 @@ module omero {
                  *
                  * @return stack size in bytes
                  *         <code>sizeX*sizeY*byteWidth</code>.
-                 **/
+                 */
                 idempotent long getStackSize() throws ServerError;
 
                 /**
@@ -112,14 +110,14 @@ module omero {
                  * a particular timepoint in this pixel store.
                  * @return timepoint size in bytes
                  *         <code>sizeX*sizeY*sizeZ*sizeC*byteWidth</code>.
-                 **/
+                 */
                 idempotent long getTimepointSize() throws ServerError;
 
                 /**
                  * Retrieves the in memory size of the entire pixel store.
                  * @return total size of the pixel size in bytes
                  *         <code>sizeX*sizeY*sizeZ*sizeC*sizeT*byteWidth</code>.
-                 **/
+                 */
                 idempotent long getTotalSize() throws ServerError;
 
                 /**
@@ -130,7 +128,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel buffer.
                  * @param t offset across the T-axis of the pixel buffer.
                  * @return offset of the row or scanline.
-                 **/
+                 */
                 idempotent long getRowOffset(int y, int z, int c, int t) throws ServerError;
 
                 /**
@@ -140,7 +138,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel buffer.
                  * @param t offset across the T-axis of the pixel buffer.
                  * @return offset of the 2D image plane.
-                 **/
+                 */
                 idempotent long getPlaneOffset(int z, int c, int t) throws ServerError;
 
                 /**
@@ -151,7 +149,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel buffer.
                  * @param t offset across the T-axis of the pixel buffer.
                  * @return offset of the stack.
-                 **/
+                 */
                 idempotent long getStackOffset(int c, int t) throws ServerError;
 
                 /**
@@ -161,7 +159,7 @@ module omero {
                  *
                  * @param t offset across the T-axis of the pixel buffer.
                  * @return offset of the timepoint.
-                 **/
+                 */
                 idempotent long getTimepointOffset(int t) throws ServerError;
 
                 /**
@@ -179,12 +177,12 @@ module omero {
 
                 /**
                  * Retrieves a n-dimensional block from this pixel store.
-                 * @param start offset for each dimension within pixel store.
+                 * @param offset offset for each dimension within pixel store.
                  * @param size of each dimension (dependent on dimension).
                  * @param step needed of each dimension (dependent on
                  *             dimension).
                  * @return buffer containing the data.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getHypercube(omero::sys::IntList offset, omero::sys::IntList size, omero::sys::IntList step) throws ServerError;
 
                 /**
@@ -192,7 +190,7 @@ module omero {
                  * @param size byte width of the region to retrieve.
                  * @param offset offset within the pixel store.
                  * @return buffer containing the data.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getRegion(int size, long offset) throws ServerError;
 
                 /**
@@ -203,7 +201,7 @@ module omero {
                  * @param t offset across the T-axis of the pixel store.
                  * @return buffer containing the data which comprises this row
                  *                or scanline.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getRow(int y, int z, int c, int t) throws ServerError;
 
                 /**
@@ -213,7 +211,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  * @return buffer containing the data which comprises this column.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getCol(int x, int z, int c, int t) throws ServerError;
 
                 /**
@@ -222,7 +220,7 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  * @return buffer containing the data which comprises this 2D image plane.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getPlane(int z, int c, int t) throws ServerError;
 
                 /**
@@ -230,12 +228,12 @@ module omero {
                  * @param z offset across the Z-axis of the pixel store.
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
-                 * @param count the number of pixels to retrieve.
-                 * @param offset the offset at which to retrieve <code>count</code> pixels.
+                 * @param size the number of pixels to retrieve.
+                 * @param offset the offset at which to retrieve <code>size</code> pixels.
                  * @return buffer containing the data which comprises the region of the
                  * given 2D image plane. It is guaranteed that this buffer will have been
                  * byte swapped.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getPlaneRegion(int z, int c, int t, int size, int offset) throws ServerError;
 
                 /**
@@ -244,14 +242,14 @@ module omero {
                  * @param c offset across the C-axis of the pixel store.
                  * @param t offset across the T-axis of the pixel store.
                  * @return buffer containing the data which comprises this stack.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getStack(int c, int t) throws ServerError;
 
                 /**
                  * Retrieves the entire number of optical sections for <b>all</b>
                  * wavelengths or channels at a particular timepoint in this pixel store.
                  * @param t offset across the T-axis of the pixel store.
-                 **/
+                 */
                 idempotent Ice::ByteSeq getTimepoint(int t) throws ServerError;
 
                 /**
@@ -279,7 +277,7 @@ module omero {
                  * @param buf a byte array of the data.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 idempotent void setRegion(int size, long offset, Ice::ByteSeq buf) throws ServerError;
 
                 /**
@@ -291,7 +289,7 @@ module omero {
                  * @param t offset across the T-axis of the pixel store.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 idempotent void setRow(Ice::ByteSeq buf, int y, int z, int c, int t) throws ServerError;
 
                 /**
@@ -302,7 +300,7 @@ module omero {
                  * @param t offset across the T-axis of the pixel store.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 idempotent void setPlane(Ice::ByteSeq buf, int z, int c, int t) throws ServerError;
 
                 /**
@@ -313,7 +311,7 @@ module omero {
                  * @param t offset across the T-axis of the pixel store.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 idempotent void setStack(Ice::ByteSeq buf, int z, int c, int t) throws ServerError;
 
                 /**
@@ -323,7 +321,7 @@ module omero {
                  * @param t offset across the T-axis of the pixel buffer.
                  *
                  * See <b>Read-only caveat</b> under {@link RawPixelsStore}
-                 **/
+                 */
                 idempotent void setTimepoint(Ice::ByteSeq buf, int t) throws ServerError;
 
                 /**
@@ -333,7 +331,7 @@ module omero {
                  * @param plane the plane (optional, default: whole region of first z/t plane)
                  * @param globalRange use the global minimum/maximum to determine the histogram range, otherwise use plane minimum/maximum value
                  * @return See above.
-                 **/
+                 */
                 idempotent IntegerIntegerArrayMap getHistogram(IntegerArray channels, int binCount, bool globalRange, omero::romio::PlaneDef plane) throws ServerError;
                 
                 /**
@@ -342,43 +340,43 @@ module omero {
                  * Note: This method can currently only handle non-pyramid images, otherwise an empty map will be returned.
                  * @param channels the channels
                  * @return See above.
-                 **/
+                 */
                 idempotent IntegerDoubleArrayMap findMinMax(IntegerArray channels) throws ServerError;
                 
                 /**
                  * Returns the byte width for the pixel store.
                  * @return See above.
-                 **/
+                 */
                 idempotent int getByteWidth() throws ServerError;
 
                 /**
                  * Returns whether or not the pixel store has signed pixels.
                  * @return See above.
-                 **/
+                 */
                 idempotent bool isSigned() throws ServerError;
 
                 /**
                  * Returns whether or not the pixel buffer has floating point pixels.
                  * @return
-                 **/
+                 */
                 idempotent bool isFloat() throws ServerError;
 
                 /**
                  * Calculates a SHA-1 message digest for the entire pixel store.
                  * @return byte array containing the message digest.
-                 **/
+                 */
                 idempotent Ice::ByteSeq calculateMessageDigest() throws ServerError;
 
                 /**
                  * Save the current state of the pixels, updating the SHA1. This should
                  * only be called AFTER all data is successfully set. Future invocations
                  * of set methods may be disallowed. This read-only status will allow
-                 * background processing (generation of thumbnails, compression, etc)
+                 * background processing (generation of thumbnails, compression, etc.)
                  * to begin. More information under {@link RawPixelsStore}.
                  *
                  * A null instance will be returned if no save was performed.
                  *
-                 **/
+                 */
                 idempotent omero::model::Pixels save() throws ServerError;
 
             };

--- a/src/main/slice/omero/api/RenderingEngine.ice
+++ b/src/main/slice/omero/api/RenderingEngine.ice
@@ -26,7 +26,7 @@ module omero {
          * planes within the pixels set onto an <i>RGB</i> image.
          *
          * The RenderingEngine allows to fine-tune the settings that
-         * define the transformation context that is, a specification
+         * define the transformation context, that is, a specification
          * of how raw pixels data is to be transformed into an image that can
          * be displayed on screen. Those settings are referred to as rendering
          * settings or display options. After tuning those settings it is

--- a/src/main/slice/omero/api/RenderingEngine.ice
+++ b/src/main/slice/omero/api/RenderingEngine.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -28,7 +26,7 @@ module omero {
          * planes within the pixels set onto an <i>RGB</i> image.
          *
          * The RenderingEngine allows to fine-tune the settings that
-         * define the transformation context &#151; that is, a specification
+         * define the transformation context that is, a specification
          * of how raw pixels data is to be transformed into an image that can
          * be displayed on screen. Those settings are referred to as rendering
          * settings or display options. After tuning those settings it is
@@ -36,13 +34,13 @@ module omero {
          * be used the next time the pixels set is accessed for rendering; for
          * example by another RenderingEngine instance. Note that the display
          * options are specific to the given pixels set and are experimenter
-         * scoped &#151; that is, two different users can specify different
+         * scoped i.e. two different users can specify different
          * display options for the <i>same</i> pixels set. (A RenderingEngine
          * instance takes this into account automatically as it is always
          * bound to a given experimenter.)
          *
          * This service is <b>thread-safe</b>.
-         **/
+         */
         ["ami", "amd"] interface RenderingEngine extends PyramidService
             {
                 /**
@@ -74,7 +72,7 @@ module omero {
                  * @return An <i>RGB</i> image ready to be displayed on screen.
                  * @throws ValidationException
                  *             If <code>def</code> is <code>null</code>.
-                 * @see {@link #render}
+                 * @see #render
                  */
                 idempotent Ice::IntSeq renderAsPackedInt(omero::romio::PlaneDef def) throws ServerError;
 
@@ -104,9 +102,8 @@ module omero {
                  *   <li><code>timepoint</code> is out of range</li>
                  *   <li><code>start</code> is out of range</li>
                  *   <li><code>end</code> is out of range</li>
-                 *   <li><code>start > end</code></li>
+                 *   <li><code>start</code> is greater than <code>end</code></li>
                  * </ul>
-                 * @see omero.api.IProjection#projectPixels
                  */
                 idempotent Ice::IntSeq renderProjectedAsPackedInt(omero::constants::projection::ProjectionType algorithm, int timepoint, int stepping, int start, int end) throws ServerError;
 
@@ -152,16 +149,15 @@ module omero {
                  *   <li><code>timepoint</code> is out of range</li>
                  *   <li><code>start</code> is out of range</li>
                  *   <li><code>end</code> is out of range</li>
-                 *   <li><code>start > end</code></li>
+                 *   <li><code>start</code>is greater than <code>end</code></li>
                  * </ul>
-                 * @see omero.api.IProjection#projectPixels
                  */
                 idempotent Ice::ByteSeq renderProjectedCompressed(omero::constants::projection::ProjectionType algorithm, int timepoint, int stepping, int start, int end) throws ServerError;
 
                 /**
                  * Returns the id of the {@link omero.model.RenderingDef}
-                 * loaded by either {@link #lookupRenderingDef} or
-                 * {@link #loadRenderingDef}.
+                 * loaded by either {@code lookupRenderingDef} or
+                 * {@code loadRenderingDef}.
                  */
                 idempotent long getRenderingDefId() throws ServerError;
 
@@ -187,7 +183,7 @@ module omero {
                  * necessarily have to be linked to the given Pixels set.
                  * However, the rendering settings <b>must</b> be linked to a
                  * compatible Pixels set as defined by
-                 * {@link omero.api.IRenderingSettings#sanityCheckPixels}.
+                 * {@code omero.api.IRenderingSettings.sanityCheckPixels}.
                  *
                  * @param renderingDefId The rendering definition ID.
                  * @throws ValidationException If a RenderingDef does not
@@ -201,7 +197,7 @@ module omero {
                  * Informs the rendering engine that it should render a set of
                  * overlays on each rendered frame. These are expected to be
                  * binary masks.
-                 * @param overlays Binary mask to color map.
+                 * @param rowColorMap Binary mask to color map.
                  */
                 ["deprecate: use omero::romio::PlaneDefWithMasks instead"] idempotent void setOverlays(omero::RLong tablesId, omero::RLong imageId, LongIntMap rowColorMap) throws ServerError;
 
@@ -304,7 +300,7 @@ module omero {
                  * @see #getChannelFamily
                  * @see #getChannelNoiseReduction
                  */
-                idempotent void setQuantizationMap(int w, omero::model::Family fam, double coefficient, bool noiseReduction) throws ServerError;
+                idempotent void setQuantizationMap(int w, omero::model::Family family, double coefficient, bool noiseReduction) throws ServerError;
 
                 /**
                  * Returns the family associated to the specified channel.
@@ -477,23 +473,23 @@ module omero {
                  * will be processed as though the specific method was called with
                  * related attributes provided as arguments. The following methods are
                  * called underneath: <ul>
-                 * <li>{@link RenderingEngine#setModel(RenderingModel)}</li>
-                 * <li>{@link RenderingEngine#setDefaultZ(int)}</li>
-                 * <li>{@link RenderingEngine#setDefaultT(int)}</li>
-                 * <li>{@link RenderingEngine#setQuantumStrategy(int)}</li>
-                 * <li>{@link RenderingEngine#setCodomainInterval(int, int)}</li>
-                 * <li>{@link RenderingEngine#setActive(int, boolean)}</li>
-                 * <li>{@link RenderingEngine#setChannelWindow(int, double, double)}</li>
-                 * <li>{@link RenderingEngine#setQuantizationMap(int, Family, double, boolean)}</li>
-                 * <li>{@link RenderingEngine#setRGBA(int, int, int, int, int)}</li>
-                 * <li>{@link RenderingEngine#setChannelLookupTable(int, String)}</li>
+                 * <li>{@code RenderingEngine.setModel}</li>
+                 * <li>{@code RenderingEngine.setDefaultZ}</li>
+                 * <li>{@code RenderingEngine.setDefaultT}</li>
+                 * <li>{@code RenderingEngine.setQuantumStrategy}</li>
+                 * <li>{@code RenderingEngine.setCodomainInterval}</li>
+                 * <li>{@code RenderingEngine.setActive}</li>
+                 * <li>{@code RenderingEngine.setChannelWindow}</li>
+                 * <li>{@code RenderingEngine.setQuantizationMap}</li>
+                 * <li>{@code RenderingEngine.setRGBA}</li>
+                 * <li>{@code RenderingEngine.setChannelLookupTable}</li>
                  * </ul>
                  * If one or more attributes that apply to a particular method are
                  * <code>null</code> it will be <b>skipped</b> in its entirety. The
                  * underlying Renderer is not able to handle partial field updates.
                  * Furthermore, {@link ome.model.display.ChannelBinding} references that are
-                 * <code>null</code> and indexes in the {@link RenderingDef#WAVERENDERING}
-                 * array greater than the currently looked up {@link Pixels#SIZEC} will be
+                 * <code>null</code> and indexes in the {@code RenderingDef.WAVERENDERING}
+                 * array greater than the currently looked up {@code Pixels.SIZEC} will be
                  * skipped.
                  */
                 idempotent void updateSettings(omero::model::RenderingDef settings) throws ServerError;
@@ -518,41 +514,36 @@ module omero {
                  */
                 long resetDefaultSettings(bool save) throws ServerError;
 
-		/**
-		 * Sets the current compression level for the service. (The
-                 * default is 85%)
-		 *
-		 * @param percentage A percentage compression level from 1.00
-                 *                  (100%) to 0.01 (1%).
-		 * @throws ValidationException if the <code>percentage</code
-                 *         is out of range.
-		 */
+		         /**
+		          * Sets the current compression level for the service. (The default is 85%)
+		          *
+		          * @param percentage A percentage compression level from 1.00 (100%) to 0.01 (1%).
+		          * @throws ValidationException if the <code>percentage</code> is out of range.
+		          */
                 idempotent void setCompressionLevel(float percentage) throws ServerError;
 
-		/**
-		 * Returns the current compression level for the service.
-		 */
+		         /**
+		          * Returns the current compression level for the service.
+		          */
                 idempotent float getCompressionLevel() throws ServerError;
 
-		/**
+		        /**
                  * Returns <code>true</code> if the pixels type is signed,
                  * <code>false</code> otherwise.
                  */
                 idempotent bool isPixelsTypeSigned() throws ServerError;
 
-		/**
+		        /**
                  * Returns the minimum value for that channels depending on
-                 * the pixels type and the original range (globalmax,
-                 * globalmin)
+                 * the pixels type and the original range (globalmin, globalmax)
                  *
                  * @param w The channel index.
                  */
                 idempotent double getPixelsTypeUpperBound(int w) throws ServerError;
 
-		/**
+		        /**
                  * Returns the maximum value for that channels depending on
-                 * the pixels type and the original range (globalmax,
-                 * globalmin)
+                 * the pixels type and the original range (globalmin, globalmax)
                  *
                  * @param w The channel index.
                  */

--- a/src/main/slice/omero/api/Search.ice
+++ b/src/main/slice/omero/api/Search.ice
@@ -18,22 +18,22 @@ module omero {
         /**
          * Central search interface, allowing Web2.0 style queries. Each
          * {@link omero.api.Search} instance keeps up with several queries and
-         * lazily-loads the results as {@link #hasNext}, {@link #next} and
-         * {@link #results} are called. These queries are created by the
+         * lazily-loads the results as {@code hasNext}, {@code next} and
+         * {@code results} are called. These queries are created by the
          * <i>by*</i> methods.
          *
          * Each instance also has a number of settings which can all be
          * changed from their defaults via accessors, e.g.
-         * {@link #setBatchSize} or {@link #setCaseSensitive}.
+         * {@code setBatchSize} or {@code setCaseSensitive}.
          *
          * The only methods which are required for the proper functioning of a
          * {@link Search} instance are:
          * <ul>
-         * <li>{@link #onlyType}, {@link #onlyTypes} OR
-         * {@link #allTypes}</li>
+         * <li>{@code onlyType}, {@code onlyTypes} OR
+         * {@code allTypes}</li>
          * <li>Any <i>by*</i> method to create a query</li>
          * </ul>
-         * Use of the {@link #allTypes} method is discouraged, since it is
+         * Use of the {@code allTypes} method is discouraged, since it is
          * possibly very resource intensive, which is why any attempt to
          * receive results without specifically setting types or allowing all
          * is prohibited.
@@ -47,8 +47,8 @@ module omero {
 
                 /**
                  * Returns the number of active queries. This means that
-                 * {@link #activeQueries} gives the minimum number of
-                 * remaining calls to {@link #results} when batches are not
+                 * {@code activeQueries} gives the minimum number of
+                 * remaining calls to {@code results} when batches are not
                  * merged.
                  *
                  * @return number of active queries
@@ -57,38 +57,37 @@ module omero {
 
                 /**
                  * Sets the maximum number of results that will be returned by
-                 * one call to {@link #results}. If batches are not merged,
+                 * one call to {@code results}. If batches are not merged,
                  * then results may often be less than the batch size. If
                  * batches are merged, then only the last call to
-                 * {@link #results} can be less than batch size.
+                 * {@code results} can be less than batch size.
                  *
                  * Note: some query types may not support batching at the
                  * query level, and all instances must then be loaded into
                  * memory simultaneously.
                  *
                  * @param size maximum number of results per call to
-                 *             {@link #results}
+                 *             {@code results}
                  */
                 idempotent void setBatchSize(int size) throws ServerError;
 
                 /**
-                 * Returns the current batch size. If {@link #setBatchSize}
+                 * Returns the current batch size. If {@code #etBatchSize}
                  * has not been called, the default value will be in effect.
                  *
-                 * @return maximum number of results per call to
-                 *         {@link #results}
+                 * @return maximum number of results per call to {@code results}
                  */
                 idempotent int getBatchSize() throws ServerError;
 
                 /**
                  * Set whether or not results from two separate queries can be
-                 * returned in the same call to {@link #results}.
+                 * returned in the same call to {@code results}.
                  */
                 idempotent void setMergedBatches(bool merge) throws ServerError;
 
                 /**
                  * Returns the current merged-batches setting. If
-                 * {@link #setMergedBatches} has not been called, the
+                 * {@code setMergedBatches} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isMergedBatches() throws ServerError;
@@ -108,7 +107,7 @@ module omero {
 
                 /**
                  * Returns the current case sensitivity setting. If
-                 * {@link #setCaseSensitive} has not been called, the
+                 * {@code setCaseSensitive} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isCaseSensitive() throws ServerError;
@@ -126,8 +125,8 @@ module omero {
                 /**
                  * Returns the current use-projection setting. If true, the
                  * client must be careful with all results that are returned.
-                 * See {@link #setUseProjections} for more. If
-                 * {@link #setUseProjections} has not been called, the
+                 * See {@code setUseProjections} for more. If
+                 * {@code setUseProjections} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isUseProjections() throws ServerError;
@@ -136,14 +135,14 @@ module omero {
                  * Determines if all results should be returned as unloaded
                  * objects. This is particularly useful for creating lists for
                  * further querying via {@link omero.api.IQuery}. This value
-                 * overrides the {@link #setUseProjections} setting.
+                 * overrides the {@code setUseProjections} setting.
                  */
                 idempotent void setReturnUnloaded(bool returnUnloaded) throws ServerError;
 
                 /**
                  * Returns the current return-unloaded setting. If true, all
                  * returned entities will be unloaded. If
-                 * {@link #setReturnUnloaded} has not been called, the
+                 * {@code codesetReturnUnloaded} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isReturnUnloaded() throws ServerError;
@@ -159,10 +158,10 @@ module omero {
 
                 /**
                  * Returns the current leading-wildcard setting. If false,
-                 * {@link #byFullText} and {@link #bySomeMustNone} will throw
+                 * {@code byFullText} and {@code bySomeMustNone} will throw
                  * an {@link omero.ApiUsageException}, since leading-wildcard
                  * searches are quite slow. Use
-                 * {@link #setAllowLeadingWildcard} in order to permit this
+                 * {@code setAllowLeadingWildcard} in order to permit this
                  * usage.
                  */
                 idempotent bool isAllowLeadingWildcard() throws ServerError;
@@ -200,8 +199,8 @@ module omero {
                 void onlyIds(omero::sys::LongList ids) throws ServerError;
 
                 /**
-                 * Uses the {@link omero.model.Details#getOwner} and
-                 * {@link omero.model.Details#getGroup} information to
+                 * Uses the {@link omero.model.Details#getOwner()} and
+                 * {@link omero.model.Details#getGroup()} information to
                  * restrict the entities which will be returned. If both are
                  * non-null, the two restrictions are joined by an AND.
                  *
@@ -211,8 +210,8 @@ module omero {
                 void onlyOwnedBy(omero::model::Details d) throws ServerError;
 
                 /**
-                 * Uses the {@link omero.model.Details#getOwner} and
-                 * {@link omero.model.Details#getGroup} information to
+                 * Uses the {@link omero.model.Details#getOwner()} and
+                 * {@link omero.model.Details#getGroup()} information to
                  * restrict the entities which will be returned. If both are
                  * non-null, the two restrictions are joined by an AND.
                  *
@@ -246,8 +245,8 @@ module omero {
                 /**
                  * Restricts entities by the time in which any annotation
                  * (which matches the other filters) was added them. This
-                 * matches the {@link omero.model.Details#getCreationEvent}
-                 * creation event of the {@link omero..model.Annotation}.
+                 * matches the {@link omero.model.Details#getCreationEvent()}
+                 * creation event of the {@link omero.model.Annotation}.
                  *
                  * @param start Can be null, i.e. interval open to negative
                  *              infinity.
@@ -259,9 +258,9 @@ module omero {
                 /**
                  * Restricts entities by who has annotated them with an
                  * {@link omero.model.Annotation} matching the other filters.
-                 * As {@link #onlyOwnedBy}, the
-                 * {@link omero.model.Details#getOwner} and
-                 * {@link omero.model.Details#getGroup} information is
+                 * As {@code onlyOwnedBy}, the
+                 * {@link omero.model.Details#getOwner()} and
+                 * {@link omero.model.Details#getGroup()} information is
                  * combined with an AND condition.
                  *
                  * @param d Can be null, in which case any previous
@@ -272,9 +271,9 @@ module omero {
                 /**
                  * Restricts entities by who has not annotated them with an
                  * {@link omero.model.Annotation} matching the other filters.
-                 * As {@link #notOwnedBy}, the
-                 * {@link omero.model.Details#getOwner} and
-                 * {@link omero.model.Details#getGroup} information is
+                 * As {@code notOwnedBy}, the
+                 * {@link omero.model.Details#getOwner()} and
+                 * {@link omero.model.Details#getGroup()} information is
                  * combined with an AND condition.
                  *
                  * @param d Can be null, in which case any previous
@@ -296,7 +295,7 @@ module omero {
                  * query each class individually, and compare all the various
                  * values, checking which ids are where. However, since this
                  * method defaults to AND, multiple calls (optionally with
-                 * {@link #isMergedBatches} and {@link #isReturnUnloaded})
+                 * {@code isMergedBatches} and {@code isReturnUnloaded})
                  * and combine the results. Duplicate ids are still possible
                  * so a set of some form should be used to collect the results.
                  *
@@ -306,7 +305,7 @@ module omero {
                 void onlyAnnotatedWith(StringSet classes) throws ServerError;
 
 
-                // Fetches, order, counts, etc ~~~~~~~~~~~~~~~~~~~~~~
+                // Fetches, order, counts, etc. ~~~~~~~~~~~~~~~~~~~~~~
 
                 /**
                  * A path from the target entity which will be added to the
@@ -406,8 +405,8 @@ module omero {
                  *                 (may be null)
                  * @param to       The date range to (inclusive), in the form
                  *                 YYYYMMDD (may be null)
-                 * @param dateType {@link #DATE_TYPE_ACQUISITION} or
-                 *                 {@link #DATE_TYPE_IMPORT}
+                 * @param dateType {@code DATE_TYPE_ACQUISITION} or
+                 *                 {@code DATE_TYPE_IMPORT}
                  * @param query May not be null or of zero length.
                  */
                 void byLuceneQueryBuilder(string fields, string from, string to, string dateType, string query) throws ServerError;
@@ -427,18 +426,17 @@ module omero {
                 void bySimilarTerms(StringSet terms) throws ServerError;
 
                 /**
-                 * Delegates to {@link omero.api.IQuery#findAllByQuery} method
-                 * to take advantage of the {@link #and}, {@link #or}, and
-                 * {@link #not} methods, or queue-semantics.
+                 * Delegates to {@code omero.api.IQuery.findAllByQuery} method
+                 * to take advantage of the {@code and}, {@code or}, and
+                 * {@code not} methods, or queue-semantics.
                  *
                  * @param query Not null.
-                 * @param p May be null. Defaults are then in effect.
-                 * @see omero.api.IQuery#findAllByQuery
+                 * @param params May be null. Defaults are then in effect.
                  */
                 void byHqlQuery(string query, omero::sys::Parameters params) throws ServerError;
 
                 /**
-                 * Builds a Lucene query and passes it to {@link #byFullText}.
+                 * Builds a Lucene query and passes it to {@code byFullText}.
                  *
                  * @param some Some (at least one) of these terms must be
                  *             present in the document. May be null.
@@ -453,12 +451,12 @@ module omero {
                  * Finds entities annotated with an
                  * {@link omero.model.Annotation} similar to the example. This
                  * does not use Hibernate's
-                 * {@link omero.api.IQuery#findByExample} Query-By-Example}
+                 * {@code omero.api.IQuery.findByExample} Query-By-Example}
                  * mechanism, since that cannot handle joins. The fields which
                  * are used are:
                  * <ul>
                  * <li>the main content of the annotation : String,
-                 * {@link omero.model.OriginalFile#getId}, etc.</li>
+                 * {@link omero.model.OriginalFile#getId()}, etc.</li>
                  * </ul>
                  *
                  * If the main content is <code>null</code> it is assumed to
@@ -471,82 +469,88 @@ module omero {
                 void byAnnotatedWith(AnnotationList examples) throws ServerError;
 
                 /**
-                 * Removes all active queries (leaving {@link #resetDefaults}
-                 * settings alone), such that {@link #activeQueries} will
+                 * Removes all active queries (leaving {@code resetDefaults}
+                 * settings alone), such that {@code activeQueries} will
                  * return 0.
                  */
                 void clearQueries() throws ServerError;
 
                 /**
                  * Applies the next by* method to the previous by* method, so
-                 * that a call {@link #hasNext}, {@link #next}, or
-                 * {@link #results} sees only the intersection of the two
+                 * that a call {@code hasNext}, {@code next}, or
+                 * {@code results} sees only the intersection of the two
                  * calls.
                  *
                  * For example,
                  *
                  * <pre>
+                 * {@code
                  * service.onlyType(Image.class);
                  * service.byFullText(&quot;foo&quot;);
                  * service.intersection();
                  * service.byAnnotatedWith(TagAnnotation.class);
+                 * }
                  * </pre>
                  *
                  * will return only the Images with TagAnnotations.
                  *
                  * <p>
                  * Calling this method overrides a previous setting of
-                 * {@link #or} or {@link #not}. If there is no active queries
-                 * (i.e. {@link #activeQueries} > 0), then an
-                 * {@link ApiUsageException} will be thrown.</p>
+                 * {@code or} or {@code not}. If there is no active queries
+                 * (i.e. {@code activeQueries > 0}), then an
+                 * {@link omero.ApiUsageException} will be thrown.</p>
                  */
                 void and() throws ServerError;
 
                 /**
                  * Applies the next by* method to the previous by* method, so
-                 * that a call {@link #hasNext}, {@link #next} or
-                 * {@link #results} sees only the union of the two calls.
+                 * that a call {@code hasNext}, {@code next} or
+                 * {@code results} sees only the union of the two calls.
                  *
                  * For example,
                  *
                  * <pre>
+                 * {@code
                  * service.onlyType(Image.class);
                  * service.byFullText(&quot;foo&quot;);
                  * service.or();
                  * service.onlyType(Dataset.class);
                  * service.byFullText(&quot;foo&quot;);
+                 * }
                  * </pre>
                  *
                  * will return both Images and Datasets together.
                  *
                  * Calling this method overrides a previous setting of
-                 * {@link #and} or {@link #not}. If there is no active queries
-                 * (i.e. {@link #activeQueries} > 0), then an
+                 * {@code and} or {@code not}. If there is no active queries
+                 * (i.e. {@code activeQueries > 0}), then an
                  * {@link omero.ApiUsageException} will be thrown.
                  */
                 void or() throws ServerError;
 
                 /**
                  * Applies the next by* method to the previous by* method, so
-                 * that a call {@link #hasNext}, {@link #next}, or
-                 * {@link #results} sees only the intersection of the two
+                 * that a call {@code hasNext}, {@code next}, or
+                 * {@code results} sees only the intersection of the two
                  * calls.
                  * 
                  * For example,
                  * 
                  * <pre>
+                 * {@code
                  * service.onlyType(Image.class);
                  * service.byFullText(&quot;foo&quot;);
                  * service.complement();
                  * service.byAnnotatedWith(TagAnnotation.class);
+                 * }
                  * </pre>
                  * 
                  * will return all the Images <em>not</em> annotated with
                  * TagAnnotation. <p>
                  * Calling this method overrides a previous setting of
-                 * {@link #or} or {@link #and}. If there is no active queries
-                 * (i.e. {@link #activeQueries} > 0), then an
-                 * {@link ApiUsageException} will be thrown.
+                 * {@code or} or {@code and}. If there is no active queries
+                 * (i.e. {@code activeQueries > 0}), then an
+                 * {@link omero.ApiUsageException} will be thrown.
                  * </p>
                  */
                 void not() throws ServerError;
@@ -556,7 +560,7 @@ module omero {
 
                 /**
                  * Returns <code>true</code> if another call to
-                 * {@link #next} is valid. A call to {@link #next} may throw
+                 * {@code next} is valid. A call to {@code next} may throw
                  * an exception for another reason, however.
                  */
                 idempotent bool hasNext() throws ServerError;
@@ -565,23 +569,23 @@ module omero {
                  * Returns the next entity from the current query. If the
                  * previous call returned the last entity from a given query,
                  * the first entity from the next query will be returned and
-                 * {@link #activeQueries} decremented.
+                 * {@code activeQueries} decremented.
                  * Since this method only returns the entity itself, a single
-                 * call to {@link #currentMetadata} may follow this call to
+                 * call to {@code currentMetadata} may follow this call to
                  * gather the extra metadata which is returned in the map via
-                 * {@link #results}.
+                 * {@code results}.
                  * 
-                 * @throws ApiUsageException if {@link #hasNext} returns false.
+                 * @throws ApiUsageException if {code hasNext} returns false.
                  */
                 omero::model::IObject next() throws ServerError;
 
                 /**
-                 * Returns up to {@link #getBatchSize} batch size number of
+                 * Returns up to {@code getBatchSize} batch size number of
                  * results along with the related query metadata. If
-                 * {@link #isMergedBatches} batches are merged then the
+                 * {@code isMergedBatches} batches are merged then the
                  * results from multiple queries may be returned together.
                  * 
-                 * @throws ApiUsageException if {@link #hasNext} returns false.
+                 * @throws ApiUsageException if {@code hasNext} returns false.
                  */
                 IObjectList results() throws ServerError;
 
@@ -589,16 +593,16 @@ module omero {
                 /**
                  * Provides access to the extra query information (for example
                  * Lucene score and boost values) for a single call to
-                 * {@link #next}. This method may only be called once for any
-                 * given call to {@link #next}.
+                 * {@code next}. This method may only be called once for any
+                 * given call to {@code next}.
                  */
                 idempotent SearchMetadata currentMetadata() throws ServerError;
 
                 /**
                  * Provides access to the extra query information (for example
                  * Lucene score and boost values) for a single call to
-                 * {@link #results}. This method may only be called once for
-                 * any given call to {@link #results}.
+                 * {@code results}. This method may only be called once for
+                 * any given call to {@code results}.
                  */
                 idempotent SearchMetadataList currentMetadataList() throws ServerError;
 

--- a/src/main/slice/omero/api/Search.ice
+++ b/src/main/slice/omero/api/Search.ice
@@ -72,7 +72,7 @@ module omero {
                 idempotent void setBatchSize(int size) throws ServerError;
 
                 /**
-                 * Returns the current batch size. If {@code #etBatchSize}
+                 * Returns the current batch size. If {@code setBatchSize}
                  * has not been called, the default value will be in effect.
                  *
                  * @return maximum number of results per call to {@code results}
@@ -142,7 +142,7 @@ module omero {
                 /**
                  * Returns the current return-unloaded setting. If true, all
                  * returned entities will be unloaded. If
-                 * {@code codesetReturnUnloaded} has not been called, the
+                 * {@code setReturnUnloaded} has not been called, the
                  * default value will be in effect.
                  */
                 idempotent bool isReturnUnloaded() throws ServerError;

--- a/src/main/slice/omero/api/ThumbnailStore.ice
+++ b/src/main/slice/omero/api/ThumbnailStore.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2010 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -24,12 +22,12 @@ module omero {
          * <p>
          * NOTE: The calling order for the service is as follows:
          * <ol>
-         * <li>{@link #setPixelsId}</li>
+         * <li>{@code setPixelsId}</li>
          * <li>any of the thumbnail accessor methods or
-         * {@link #resetDefaults}</li>
+         * {@code resetDefaults}</li>
          * </ol>
          * </p>
-         **/
+         */
         ["ami", "amd"] interface ThumbnailStore extends StatefulServiceInterface
             {
                 /**
@@ -63,7 +61,7 @@ module omero {
 
                 /**
                  * This method manages the state of the service; it should be
-                 * invoked directly after {@link #setPixelsId}. If it is not
+                 * invoked directly after {@code setPixelsId}. If it is not
                  * invoked with a valid rendering definition ID before using
                  * the thumbnail accessor methods execution continues as if
                  * <code>renderingDefId</code> were set to <code>null</code>.
@@ -89,7 +87,7 @@ module omero {
                  * rendering settings (RenderingDef). If the thumbnail exists
                  * in the on-disk cache it will be returned directly,
                  * otherwise it will be created as in
-                 * {@link #getThumbnailDirect}, placed in the on-disk
+                 * {@code getThumbnailDirect}, placed in the on-disk
                  * cache and returned. If the thumbnail is missing, a clock will
                  * be returned to signify that the thumbnail is yet to be generated.
                  *
@@ -102,11 +100,11 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
                  *             <li><code>sizeX</code> is negative</li>
-                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
                  *             <li><code>sizeY</code> is negative</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnailDirect
@@ -118,7 +116,7 @@ module omero {
                  * rendering settings (RenderingDef). If the thumbnail exists
                  * in the on-disk cache it will be returned directly,
                  * otherwise it will be created as in
-                 * {@link #getThumbnailDirect}, placed in the on-disk
+                 * {@code getThumbnailDirect}, placed in the on-disk
                  * cache and returned. If the thumbnail is still to be generated, an empty array will
                  * be returned.
                  *
@@ -131,11 +129,11 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
                  *             <li><code>sizeX</code> is negative</li>
-                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
                  *             <li><code>sizeY</code> is negative</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer
                  * @see #getThumbnailDirect
@@ -147,10 +145,10 @@ module omero {
                  * given sets of rendering settings (RenderingDef). If the
                  * thumbnails exist in the on-disk cache they will be returned
                  * directly, otherwise they will be created as in
-                 * {@link #getThumbnailDirect}, placed in the on-disk cache
+                 * {@code getThumbnailDirect}, placed in the on-disk cache
                  * and returned. Unlike the other thumbnail retrieval methods,
                  * this method <b>may</b> be called without first calling
-                 * {@link #setPixelsId}.
+                 * {@code setPixelsId}.
                  *
                  * @param sizeX the X-axis width of the thumbnail.
                  *              <code>null</code> specifies the default size
@@ -172,12 +170,12 @@ module omero {
                  * given sets of rendering settings (RenderingDef). If the
                  * Thumbnails exist in the on-disk cache they will be returned
                  * directly, otherwise they will be created as in
-                 * {@link #getThumbnailByLongestSideDirect}. The longest
+                 * {@code getThumbnailByLongestSideDirect}. The longest
                  * side of the image will be used to calculate the size for
                  * the smaller side in order to keep the aspect ratio of the
                  * original image. Unlike the other thumbnail retrieval
                  * methods, this method <b>may</b> be called without first
-                 * calling {@link #setPixelsId}.
+                 * calling {@code setPixelsId}.
                  *
                  * @param size the size of the longest side of the thumbnail
                  *             requested. <code>null</code> specifies the
@@ -194,8 +192,8 @@ module omero {
                 /**
                  * Retrieves a thumbnail for a pixels set using a given set of
                  * rendering settings (RenderingDef). If the thumbnail exists
-                 * in the on-disk cache it will bereturned directly, otherwise
-                 * it will be created as in {@link #getThumbnailDirect},
+                 * in the on-disk cache it will be returned directly, otherwise
+                 * it will be created as in {@code getThumbnailDirect},
                  * placed in the on-disk cache and returned. The longest side
                  * of the image will be used to calculate the size for the
                  * smaller side in order to keep the aspect ratio of the
@@ -206,8 +204,8 @@ module omero {
                  *             default size of 48.
                  * @throws ApiUsageException if:
                  *         <ul>
-                 *         <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
-                 *         <li>{@link #setPixelsId} has not yet been called</li>
+                 *         <li><code>size</code> is greater than pixels.sizeX and pixels.sizeY</li>
+                 *         <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnail
@@ -228,8 +226,8 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li><code>size</code> is greater than pixels.sizeX and pixels.sizeY</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnailDirect
@@ -250,11 +248,11 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
                  *             <li><code>sizeX</code> is negative</li>
-                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
                  *             <li><code>sizeY</code> is negative</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnail
@@ -279,13 +277,13 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>sizeX</code> > pixels.sizeX</li>
+                 *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
                  *             <li><code>sizeX</code> is negative</li>
-                 *             <li><code>sizeY</code> > pixels.sizeY</li>
+                 *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
                  *             <li><code>sizeY</code> is negative</li>
                  *             <li><code>theZ</code> is out of range</li>
                  *             <li><code>theT</code> is out of range</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnail
@@ -309,8 +307,8 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
-                 *             <li>{@link #setPixelsId} has not yet been called</li>
+                 *             <li><code>size</code> is greater than pixels.sizeX and pixels.sizeY</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @return a JPEG thumbnail byte buffer.
                  * @see #getThumbnailDirect
@@ -340,11 +338,11 @@ module omero {
                   * @throws ApiUsageException
                   *             if:
                   *             <ul>
-                  *             <li><code>sizeX</code> > pixels.sizeX</li>
+                  *             <li><code>sizeX</code> is greater than pixels.sizeX</li>
                   *             <li><code>sizeX</code> is negative</li>
-                  *             <li><code>sizeY</code> > pixels.sizeY</li>
+                  *             <li><code>sizeY</code> is greater than pixels.sizeY</li>
                   *             <li><code>sizeY</code> is negative</li>
-                  *             <li>{@link #setPixelsId} has not yet been called</li>
+                  *             <li>{@code setPixelsId} has not yet been called</li>
                   *             </ul>
                   * @see #getThumbnail
                   * @see #getThumbnailDirect
@@ -356,7 +354,7 @@ module omero {
                  * given set of rendering settings (RenderingDef) in the
                  * on-disk cache. Unlike the other thumbnail creation methods,
                  * this method <b>may</b> be called without first calling
-                 * {@link #setPixelsId}. This method <b>will not</b> reset or
+                 * {@code setPixelsId}. This method <b>will not</b> reset or
                  * modify rendering settings in any way. If rendering settings
                  * for a pixels set are not present, thumbnail creation for
                  * that pixels set <b>will not</b> be performed.
@@ -368,7 +366,7 @@ module omero {
                  * @throws ApiUsageException
                  *             if:
                  *             <ul>
-                 *             <li><code>size</code> > pixels.sizeX and pixels.sizeY</li>
+                 *             <li><code>size</code> is greater than pixels.sizeX and pixels.sizeY</li>
                  *             <li><code>size</code> is negative</li>
                  *             </ul>
                  * @see #createThumbnail

--- a/src/main/slice/omero/cmd/API.ice
+++ b/src/main/slice/omero/cmd/API.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *

--- a/src/main/slice/omero/cmd/Admin.ice
+++ b/src/main/slice/omero/cmd/Admin.ice
@@ -25,7 +25,7 @@ module omero {
           * examples:
           *  - omero.cmd.ResetPasswordRequest(omename, email)
           *      sends new password to the given user
-          **/
+          */
          class ResetPasswordRequest extends Request {
              string omename;
              string email;
@@ -35,7 +35,7 @@ module omero {
           * Successful response for {@link ResetPasswordRequest}.
           * If no valid user with matching email is found,
           * an {@link ERR} will be returned.
-          **/
+          */
          class ResetPasswordResponse extends Response {
          };
 
@@ -58,7 +58,7 @@ module omero {
         /**
          * Argument-less request that will produce a
          * {@link CurrentSessionsResponse} if no {@link omero.cmd.ERR} occurs.
-         **/
+         */
         class CurrentSessionsRequest extends Request {
         };
 
@@ -69,12 +69,12 @@ module omero {
          * objects that are currently active *after* all timeouts have been
          * applied.
          * This is the value that would be returned by
-         * {@link omero.api.ISession#getSession} when joined to that session.
+         * {@code omero.api.ISession.getSession} when joined to that session.
          * Similarly, the contexts field contains the value that would be
-         * returned by a call to {@link omero.api.IAdmin#getEventContext}.
+         * returned by a call to {@code omero.api.IAdmin.getEventContext}.
          * For non-administrators, most values for all sessions other than
-         * those belonging to that user will be nulled.
-         **/
+         * those belonging to that user will be null.
+         */
         class CurrentSessionsResponse extends Response {
 
             /**

--- a/src/main/slice/omero/cmd/Basic.ice
+++ b/src/main/slice/omero/cmd/Basic.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2011 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -22,7 +20,7 @@ module omero {
             /**
              * List of call context objects which should get applied to each Request.
              * The list need only be as large as necessary to apply to a given request.
-             * Null and empty {@link StringMap} instances will be ignored.
+             * Null and empty {@code StringMap} instances will be ignored.
              **/
             StringMapList contexts;
         };
@@ -64,20 +62,20 @@ module omero {
          * Diagnostic command which can be used to see the overhead
          * of callbacks. The number of steps and the simulated workload
          * can be specified.
-         **/
+         */
         class Timing extends Request {
 
             /**
              * Number of steps that will be run by this command. Value is
              * limited by the overall invocation time (5 minutes) as well as
              * total number of calls (e.g. 100000)
-             **/
+             */
             int steps;
 
             /**
              * Number of millis to wait. This value simulates activity on the server.
              * Value is limited by the overall invocation time (5 minutes).
-             **/
+             */
             int millisPerStep;
         };
     };

--- a/src/main/slice/omero/cmd/FS.ice
+++ b/src/main/slice/omero/cmd/FS.ice
@@ -31,21 +31,21 @@ module omero {
          * Requests all pyramids files. A {@link FindPyramidsResponse}
          * will be returned under normal conditions, otherwise a {@link ERR}
          * will be returned.
-         **/
+         */
         class FindPyramids extends Request {
 
             /**
              * Retrieves the pyramids with little endian true or false.
              * If unset, both will be retrieved.
-             **/
+             */
             omero::RBool littleEndian;
             /**
              * Retrieves the pyramids created after a specified time if set.
-             **/
+             */
             omero::RTime importedAfter;
             /**
              * Retrieves the pyramids of length 0 if true
-             **/
+             */
             bool checkEmptyFile;
             /**
              * The maximum number of files to find. No limit will be applied
@@ -83,9 +83,9 @@ module omero {
         /**
          * Successful response for {@link OriginalMetadataRequest}. Contains
          * both the global and the series metadata as maps. Only one
-         * of {@link #filesetId} or {@link #filesetAnnotationId} will be set.
-         * Pre-FS images will have {@link #filesetAnnotationId} set; otherwise
-         * {@link #filesetId} will be set.
+         * of {@code filesetId} or {@code filesetAnnotationId} will be set.
+         * Pre-FS images will have {@code filesetAnnotationId} set; otherwise
+         * {@code filesetId} will be set.
          **/
         class OriginalMetadataResponse extends Response {
 
@@ -96,7 +96,7 @@ module omero {
             omero::RLong filesetId;
 
             /**
-             * Set to the id of the {@link omero.model.FilesetAnnotation}
+             * Set to the id of the {@link omero.model.FileAnnotation}
              * linked to this {@link omero.model.Image} if one exists.
              **/
             omero::RLong fileAnnotationId;
@@ -111,7 +111,7 @@ module omero {
              * Metadata specific to the series id of this
              * {@link omero.model.Image}.
              * In the {@link omero.model.Fileset} that this
-             * {@link omero.model.Image] is contained in, there may be a large
+             * {@link omero.model.Image} is contained in, there may be a large
              * number of other images, but the series metadata applies only to
              * this specific one.
              **/
@@ -249,7 +249,7 @@ module omero {
          * Disk usage report: bytes used and non-empty file counts on the
          * repository file-system for specific objects. The counts from the
          * maps may sum to more than the total if different types of object
-         * refer to the same file. Common referers include:
+         * refer to the same file. Common referrers include:
          *   Annotation for file annotations
          *   FilesetEntry for OMERO 5 image files (OMERO.fs)
          *   Job for import logs

--- a/src/main/slice/omero/cmd/Graphs.ice
+++ b/src/main/slice/omero/cmd/Graphs.ice
@@ -23,7 +23,7 @@ module omero {
          * For annotations, each override is limited to specific annotation
          * namespaces. (If no namespaces are specified, defaults apply
          * according to the configuration of the graph request factory.)
-         **/
+         */
         module graphs {
 
             /**
@@ -33,29 +33,29 @@ module omero {
              * At least one of includeType or excludeType must be used;
              * if a type matches both, then it is included.
              * No more than one of includeNs and excludeNs may be used.
-             **/
+             */
             class ChildOption {
 
                 /**
                  * Include in the operation all children of these types.
-                 **/
+                 */
                 omero::api::StringSet includeType;
 
                 /**
                  * Include in the operation no children of these types.
-                 **/
+                 */
                 omero::api::StringSet excludeType;
 
                 /**
                  * For annotations, limit the applicability of this option
                  * to only those in these namespaces.
-                 **/
+                 */
                 omero::api::StringSet includeNs;
 
                 /**
                  * For annotations, limit the applicability of this option
                  * to only those not in these namespaces.
-                 **/
+                 */
                 omero::api::StringSet excludeNs;
             };
 
@@ -63,39 +63,39 @@ module omero {
              * A list of if GraphModify2 requests should operate on
              * specific kinds of children.
              * Only the first applicable option takes effect.
-             **/
+             */
             ["java:type:java.util.ArrayList<omero.cmd.graphs.ChildOption>:java.util.List<omero.cmd.graphs.ChildOption>"]
             sequence<ChildOption> ChildOptions;
         };
 
         /**
          * Base class for new requests for reading the model object graph.
-         **/
+         */
         class GraphQuery extends Request {
 
             /**
              * The model objects upon which to operate.
              * Related model objects may also be targeted.
-             **/
+             */
             omero::api::StringLongListMap targetObjects;
         };
 
         /**
          * Base class for new requests for modifying the model object graph.
-         **/
+         */
         class GraphModify2 extends GraphQuery {
 
             /**
              * If the request should operate on specific kinds of children.
              * Only the first applicable option takes effect.
-             **/
+             */
             graphs::ChildOptions childOptions;
 
             /**
              * If this request should skip the actual model object updates.
              * The response is still as if the operation actually occurred,
              * indicating what would have been done to which objects.
-             **/
+             */
             bool dryRun;
         };
 
@@ -103,30 +103,30 @@ module omero {
          * Move model objects into a different experimenter group.
          * The user must be either an administrator,
          * or the owner of the objects and a member of the target group.
-         **/
+         */
         class Chgrp2 extends GraphModify2 {
 
             /**
              * The ID of the experimenter group into which to move the model
              * objects.
-             **/
+             */
             long groupId;
         };
 
         /**
          * Result of moving model objects into a different experimenter
          * group.
-         **/
+         */
         class Chgrp2Response extends OK {
 
             /**
              * The model objects that were moved.
-             **/
+             */
             omero::api::StringLongListMap includedObjects;
 
             /**
              * The model objects that were deleted.
-             **/
+             */
             omero::api::StringLongListMap deletedObjects;
         };
 
@@ -135,28 +135,28 @@ module omero {
          * The user must be an administrator, the owner of the objects,
          * or an owner of the objects' group.
          * The only permitted target object type is ExperimenterGroup.
-         **/
+         */
         class Chmod2 extends GraphModify2 {
 
             /**
              * The permissions to set on the model objects.
-             **/
+             */
             string permissions;
         };
 
         /**
          * Result of changing the permissions on model objects.
-         **/
+         */
         class Chmod2Response extends OK {
 
             /**
              * The model objects with changed permissions.
-             **/
+             */
             omero::api::StringLongListMap includedObjects;
 
             /**
              * The model objects that were deleted.
-             **/
+             */
             omero::api::StringLongListMap deletedObjects;
         };
 
@@ -165,7 +165,7 @@ module omero {
          * The user must be an administrator, or they
          * must be an owner of the objects' group, with
          * the target user a member of the objects' group.
-         **/
+         */
         class Chown2 extends GraphModify2 {
 
             /**
@@ -182,7 +182,7 @@ module omero {
 
         /**
          * Result of changing the ownership of model objects.
-         **/
+         */
         class Chown2Response extends OK {
 
             /**
@@ -198,23 +198,23 @@ module omero {
 
         /**
          * Delete model objects.
-         **/
+         */
         class Delete2 extends GraphModify2 {
                 /**
                  * Ignore in the operation all objects of these types.
-                 **/
+                 */
                 ["deprecate:experimental: may be wholly removed in next major version"]
                 omero::api::StringSet typesToIgnore;
         };
 
         /**
          * Result of deleting model objects.
-         **/
+         */
         class Delete2Response extends OK {
 
             /**
              * The model objects that were deleted.
-             **/
+             */
             omero::api::StringLongListMap deletedObjects;
         };
 
@@ -227,7 +227,7 @@ module omero {
          * request's dryRun is set to true then the dryRun override
          * persists throughout the operation. The response from SkipHead
          * is as from the given request.
-         **/
+         */
         class SkipHead extends GraphModify2 {
 
             /**
@@ -235,7 +235,7 @@ module omero {
              * operation. These are children, directly or indirectly, of
              * the target objects. These children become the true target
              * objects of the underlying request.
-             **/
+             */
             omero::api::StringSet startFrom;
 
             /**
@@ -244,7 +244,7 @@ module omero {
              * is the SkipHead request that specifies the parent objects.
              * Only specific request types are supported
              * (those implementing WrappableRequest).
-             **/
+             */
             GraphModify2 request;
         };
 
@@ -258,7 +258,7 @@ module omero {
          *   ExperimenterGroup, Experimenter, Project, Dataset,
          *   Folder, Screen, Plate, Well, WellSample,
          *   Image, Pixels, Annotation, Job, Fileset, OriginalFile.
-         **/
+         */
         class DiskUsage2 extends GraphQuery {
             omero::api::StringSet targetClasses;
         };
@@ -274,7 +274,7 @@ module omero {
          *   Pixels for pyramids and OMERO 4 images and archived files
          *   Thumbnail for the image thumbnails
          * The above map values are broken down by owner-group keys.
-         **/
+         */
         class DiskUsage2Response extends Response {
             omero::api::LongPairToStringIntMap fileCountByReferer;
             omero::api::LongPairToStringLongMap bytesUsedByReferer;
@@ -289,49 +289,49 @@ module omero {
          * subgraph. The same type must not be listed in more than one of
          * those data members. Use of a more specific sub-type in a data
          * member always overrides the more general type in another.
-         **/
+         */
         class Duplicate extends GraphModify2 {
 
             /**
              * The types of the model objects to actually duplicate.
-             **/
+             */
             omero::api::StringSet typesToDuplicate;
 
             /**
              * The types of the model objects that should not be duplicated
              * but that may participate in references involving duplicates.
-             **/
+             */
             omero::api::StringSet typesToReference;
 
             /**
              * The types of the model objects that should not be duplicated
              * and that may not participate in references involving duplicates.
-             **/
+             */
             omero::api::StringSet typesToIgnore;
         };
 
         /**
          * Result of duplicating model objects.
-         **/
+         */
         class DuplicateResponse extends OK {
 
             /**
              * The duplicate model objects created by the request.
              * Note: If dryRun is set to true then this instead lists the model
              * objects that would have been duplicated.
-             **/
+             */
             omero::api::StringLongListMap duplicates;
         };
 
         /**
          * Identify the parents or containers of model objects.
          * Traverses the model graph to identify indirect relationships.
-         **/
+         */
         class FindParents extends GraphQuery {
 
             /**
              * The types of parents being sought.
-             **/
+             */
             omero::api::StringSet typesOfParents;
 
             /**
@@ -339,30 +339,30 @@ module omero {
              * search. Search does not include or pass such objects.
              * For efficiency the server automatically excludes various
              * classes depending on the other arguments of the request.
-             **/
+             */
             omero::api::StringSet stopBefore;
         };
 
         /**
          * Result of identifying the parents or containers of model objects.
-         **/
+         */
         class FoundParents extends OK {
 
             /**
              * The parents that were identified.
-             **/
+             */
             omero::api::StringLongListMap parents;
         };
 
         /**
          * Identify the children or contents of model objects.
          * Traverses the model graph to identify indirect relationships.
-         **/
+         */
         class FindChildren extends GraphQuery {
 
             /**
              * The types of children being sought.
-             **/
+             */
             omero::api::StringSet typesOfChildren;
 
             /**
@@ -370,18 +370,18 @@ module omero {
              * search. Search does not include or pass such objects.
              * For efficiency the server automatically excludes various
              * classes depending on the other arguments of the request.
-             **/
+             */
             omero::api::StringSet stopBefore;
         };
 
         /**
          * Result of identifying the children or contents of model objects.
-         **/
+         */
         class FoundChildren extends OK {
 
             /**
              * The children that were identified.
-             **/
+             */
             omero::api::StringLongListMap children;
         };
 
@@ -389,23 +389,23 @@ module omero {
          * Graph requests typically allow only specific model object classes
          * to be targeted. This request lists the legal targets for a given
          * request. The request's fields are ignored, only its class matters.
-         **/
+         */
         class LegalGraphTargets extends Request {
 
             /**
              * A request of the type being queried.
-             **/
+             */
             GraphQuery request;
         };
 
         /**
          * A list of the legal targets for a graph request.
-         **/
+         */
         class LegalGraphTargetsResponse extends OK {
 
             /**
              * The legal targets for the given request's type.
-             **/
+             */
             omero::api::StringSet targets;
         };
 
@@ -413,12 +413,12 @@ module omero {
          * Returned when specifically a ome.services.graphs.GraphException
          * is thrown. The contents of that internal exception are passed in
          * this instance.
-         **/
+         */
         class GraphException extends ERR {
 
             /**
              * The message of the GraphException.
-             **/
+             */
              string message;
         };
     };

--- a/src/main/slice/omero/cmd/Mail.ice
+++ b/src/main/slice/omero/cmd/Mail.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2014 University of Dundee. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -38,7 +36,7 @@ module omero {
          *      userIds=\[...] )
          *      sends email to active members of given groups and selected users
          *  - extra=\[...] allows to set extra email address if not in DB
-         **/
+         */
          class SendEmailRequest extends Request {
              string subject;
              string body;
@@ -51,9 +49,9 @@ module omero {
          };
 
          /**
-         * Successful response for {@link SendEmailRequest}. Contains
+         * Successful response for {@code SendEmailRequest}. Contains
          * a list of invalid users that has no email address set.
-         * If no recipients or invalid users found, an {@link ERR} will be
+         * If no recipients or invalid users found, an {@code ERR} will be
          * returned.
          *
          * - invalidusers is a list of userIds that email didn't pass criteria
@@ -61,7 +59,7 @@ module omero {
          * - invalidemails is a list of email addresses that send email failed
          * - total is a total number of email in the pull to be sent.
          * - success is a number of emails that were sent successfully.
-         **/
+         */
          class SendEmailResponse extends Response {
              long total;
              long success;

--- a/src/main/slice/omero/model/Details.ice
+++ b/src/main/slice/omero/model/Details.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -21,7 +19,7 @@ module omero {
      * Embedded component of every OMERO.blitz type. Since this is
      * not an IObject subclass, no attempt is made to hide the state
      * of this object, since it cannot be ""unloaded"".
-     **/
+     */
     ["protected"] class Details
     {
 
@@ -65,14 +63,14 @@ module omero {
        * the last (optional) argument of any remote
        * Ice invocation. This is used to change the
        * user, group, share, etc. of the current session.
-       **/
+       */
       Ice::Context call;
 
       /**
        * Context which would have been returned by a
-       * simultaneous call to {@link omero.api.IAdmin#getEventContext}
+       * simultaneous call to {@code omero.api.IAdmin.getEventContext}
        * while this object was being loaded.
-       **/
+       */
       omero::sys::EventContext event;
 
     };

--- a/src/main/slice/omero/model/ElectricPotential.ice
+++ b/src/main/slice/omero/model/ElectricPotential.ice
@@ -34,7 +34,7 @@ module omero {
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. detectorSettings.voltage
        * and detectorSettings.voltageUnit).
-       **/
+       */
     ["protected"] class ElectricPotential
     {
 
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsElectricPotential} enum.
-       **/
+       */
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsElectricPotential} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       **/
+       */
       omero::model::enums::UnitsElectricPotential getUnit();
 
       void setUnit(omero::model::enums::UnitsElectricPotential unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       **/
+       */
       string getSymbol();
 
       ElectricPotential copy();

--- a/src/main/slice/omero/model/Frequency.ice
+++ b/src/main/slice/omero/model/Frequency.ice
@@ -34,7 +34,7 @@ module omero {
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. detectorSettings.readOutRate
        * and detectorSettings.readOutRateUnit).
-       **/
+       */
     ["protected"] class Frequency
     {
 
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsFrequency} enum.
-       **/
+       */
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsFrequency} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       **/
+       */
       omero::model::enums::UnitsFrequency getUnit();
 
       void setUnit(omero::model::enums::UnitsFrequency unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       **/
+       */
       string getSymbol();
 
       Frequency copy();

--- a/src/main/slice/omero/model/IObject.ice
+++ b/src/main/slice/omero/model/IObject.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -20,21 +18,21 @@ module omero {
      * server, the interface ome.model.IObject
      * unifies the model. In Ice, interfaces have
      * a more remote connotation.
-     **/
+     */
     ["protected"] class IObject
     {
       /**
        * The database id for this entity. Of RLong value
        * so that transient entities can have a null id.
-       **/
-      omero::RLong          id;
+       */
+      omero::RLong id;
 
       /**
        * Internal details (permissions, owner, etc.) for
        * this entity. All entities have Details, and even
        * a newly created object will have a non-null
        * Details instance. (In the OMERO provided mapping!)
-       **/
+       */
       omero::model::Details details;
 
       /**
@@ -42,7 +40,7 @@ module omero {
        * exception will be raised if any field other than id is
        * accessed via the OMERO-generated methods. Unloaded objects
        * are useful as pointers or proxies to server-side state.
-       **/
+       */
       bool loaded;
 
       // METHODS
@@ -59,21 +57,21 @@ module omero {
       /**
        * Return another instance of the same type as this instance
        * constructed as if by: new InstanceI( this.id.val, false );
-       **/
+       */
       IObject proxy();
 
       /**
        * Return another instance of the same type as this instance
        * with all single-value entities unloaded and all members of
        * collections also unloaded.
-       **/
+       */
       IObject shallowCopy();
 
       /**
        * Sets the loaded boolean to false and empties all state
        * from this entity to make sending it over the network
        * less costly.
-       **/
+       */
       void unload();
 
       /**
@@ -88,18 +86,18 @@ module omero {
        *
        * Sending back empty collections can also save a significant
        * amount of bandwidth, when working with large data graphs.
-       **/
+       */
       void unloadCollections();
 
       /**
        * As with collections, the objects under details can link
        * to many other objects. Unloading the details can same
        * bandwidth and simplify the server logic.
-       **/
+       */
       void unloadDetails();
 
       /**
-       * Tests for unloadedness. If this value is false, then
+       * Tests if the objects are loaded or not. If this value is false, then
        * any method call on this instance other than getId
        * or setId will result in an exception.
        **/
@@ -116,7 +114,7 @@ module omero {
       /**
        * Marker interface which means that special rules apply
        * for both reading and writing these instances.
-       **/
+       */
       bool isGlobal();
 
       /**
@@ -125,7 +123,7 @@ module omero {
        *
        *   - getParent()
        *   - getChild()
-       **/
+       */
       bool isLink();
 
       /**
@@ -135,7 +133,7 @@ module omero {
        *   - getVersion()
        *   - setVersion()
        *
-       **/
+       */
       bool isMutable();
 
       /**
@@ -144,7 +142,7 @@ module omero {
        *
        *   - linkAnnotation(Annotation)
        *   -
-       **/
+       */
       bool isAnnotated();
 
 

--- a/src/main/slice/omero/model/Length.ice
+++ b/src/main/slice/omero/model/Length.ice
@@ -34,7 +34,7 @@ module omero {
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. pixels.physicalSizeX
        * and pixels.physicalSizeXUnit).
-       **/
+       */
     ["protected"] class Length
     {
 
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsLength} enum.
-       **/
+       */
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsLength} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       **/
+       */
       omero::model::enums::UnitsLength getUnit();
 
       void setUnit(omero::model::enums::UnitsLength unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       **/
+       */
       string getSymbol();
 
       Length copy();

--- a/src/main/slice/omero/model/NamedValue.ice
+++ b/src/main/slice/omero/model/NamedValue.ice
@@ -28,7 +28,7 @@ module omero {
     /**
      * Simple Pair-like container which is
      * used in a sequence to support ordered maps.
-     **/
+     */
     class NamedValue {
         string name;
         string value;

--- a/src/main/slice/omero/model/Permissions.ice
+++ b/src/main/slice/omero/model/Permissions.ice
@@ -18,7 +18,7 @@ module omero {
        * Row-level permissions definition available on
        * every OMERO.blitz type. Represents a similar
        * logic to the Unix filesystem.
-       **/
+       */
     ["protected"] class Permissions
     {
 
@@ -30,7 +30,7 @@ module omero {
        * assume that there is no such restriction.
        *
        * If null, this should be assumed to have no restrictions.
-       **/
+       */
       omero::api::BoolArray restrictions;
 
       /**
@@ -39,9 +39,9 @@ module omero {
        * which strings MAY NOT be present in this field for
        * execution to be successful. For example, if an
        * {@link omero.model.Image} contains a ""DOWNLOAD"" restriction,
-       * then an attempt to call {@link omero.api.RawFileStore#read}
+       * then an attempt to call {@code omero.api.RawFileStore.read}
        * will fail with an {@link omero.SecurityViolation}.
-       **/
+       */
       omero::api::StringSet extendedRestrictions;
 
       /**
@@ -50,18 +50,18 @@ module omero {
        * accessors are provided for the perm1 instance though it
        * is protected, though NO GUARANTEES are made on the
        * representation.
-       **/
+       */
       long perm1;
 
       /**
        * Do not use!
-       **/
+       */
       long getPerm1();
 
       /**
        * Do not use!
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setPerm1(long value);
 
       // Context-based values
@@ -75,14 +75,14 @@ module omero {
        *
        * isDisallow(ANNOTATERESTRICTION) == ! canAnnotate()
        *
-       **/
+       */
        bool isDisallow(int restriction);
 
       /**
        * Returns true if the given argument is present in the
        * extendedRestrictions set. This implies that some
        * service-specific behavior is disallowed.
-       **/
+       */
        bool isRestricted(string restriction);
 
       /**
@@ -91,7 +91,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canAnnotate();
 
       /**
@@ -101,7 +101,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canEdit();
 
       /**
@@ -110,7 +110,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canLink();
 
       /**
@@ -119,7 +119,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canDelete();
 
       /**
@@ -128,7 +128,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canChgrp();
 
       /**
@@ -137,7 +137,7 @@ module omero {
        *
        * The fact that the user has this object in hand
        * already identifies that it's readable.
-       **/
+       */
       bool canChown();
 
       // Row-based values
@@ -161,47 +161,47 @@ module omero {
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setUserRead(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setUserAnnotate(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setUserWrite(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setGroupRead(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setGroupAnnotate(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setGroupWrite(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setWorldRead(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setWorldAnnotate(bool value);
 
       /**
        * Throws {@link omero.ClientError} if mutation not allowed.
-       **/
+       */
       void setWorldWrite(bool value);
 
     };

--- a/src/main/slice/omero/model/RTypes.ice
+++ b/src/main/slice/omero/model/RTypes.ice
@@ -1,6 +1,4 @@
 /*
- *   $Id$
- *
  *   Copyright 2007 Glencoe Software, Inc. All rights reserved.
  *   Use is subject to license terms supplied in LICENSE.txt
  *
@@ -19,7 +17,7 @@ module omero {
 
   /**
    * Wrapper for an {@link omero.model.IObject} instance.
-   **/
+   */
   ["protected"] class RObject extends RType
   {
     omero::model::IObject val;


### PR DESCRIPTION
fix javadoc warnings
In order to see if some warnings remain, you will need to use Java version > 1.8 (tested with Java 11)
Currently no warnings are returned if Java 1.8 is used
To check run gradle javadoc

14 warnings will remain. They should all happen under ``src/main/java/omero/gateway``. This is fixed in the new repo See https://github.com/ome/omero-java-gateway/pull/1