### PR TITLE
Bring omero-common-test dependency up to 5.5.0-m6.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("org.testng:testng:6.14.2")
     testImplementation('nl.javadude.assumeng:assumeng:1.2.4')
-    testImplementation('org.openmicroscopy:omero-common-test:5.5.0-m4')
+    testImplementation('org.openmicroscopy:omero-common-test:5.5.0-m6')
 
     api("org.openmicroscopy:omero-server:5.5.0-m6")
 


### PR DESCRIPTION
May assist with transitive dependency conflicts.