### PR TITLE
Do real file deletions in same order as deletion processing.

### DIFF
--- a/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
+++ b/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
@@ -87,9 +87,10 @@ public abstract class BaseGraphTraversalProcessor implements GraphTraversal.Proc
      */
     public void deleteFiles(Deletion deletionInstance) {
         for (final Map.Entry<String, Collection<Long>> deletionBatch : deletionLog) {
-            final ImmutableSetMultimap.Builder<String, Long> targets = ImmutableSetMultimap.builder();
-            targets.putAll(deletionBatch.getKey(), deletionBatch.getValue());
-            deletionInstance.deleteFiles(targets.build());
+            deletionInstance.deleteFiles(
+                    ImmutableSetMultimap.<String, Long>builder()
+                    .putAll(deletionBatch.getKey(), deletionBatch.getValue())
+                    .build());
         }
         deletionLog.clear();
     }

--- a/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
+++ b/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -19,13 +19,24 @@
 
 package omero.cmd.graphs;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.Maps;
+
+import ome.model.core.OriginalFile;
+import ome.model.core.Pixels;
+import ome.model.display.Thumbnail;
 import ome.model.internal.Details;
+import ome.services.delete.Deletion;
 import ome.services.graphs.GraphException;
 import ome.services.graphs.GraphTraversal;
 
@@ -38,7 +49,13 @@ public abstract class BaseGraphTraversalProcessor implements GraphTraversal.Proc
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseGraphTraversalProcessor.class);
 
+    /* compare with ome.services.delete.files.FileDeleter.Type */
+    private static final Collection<String> DELETION_CLASS_NAMES = ImmutableSet.of(
+            OriginalFile.class.getName(), Pixels.class.getName(), Thumbnail.class.getName());
+
     protected final Session session;
+
+    private final List<Map.Entry<String, Collection<Long>>> deletionLog = new ArrayList<>();
 
     public BaseGraphTraversalProcessor(Session session) {
         this.session = session;
@@ -58,6 +75,23 @@ public abstract class BaseGraphTraversalProcessor implements GraphTraversal.Proc
         if (count != ids.size()) {
             LOGGER.warn("not all the objects of type " + className + " could be deleted");
         }
+        if (DELETION_CLASS_NAMES.contains(className)) {
+            deletionLog.add(Maps.immutableEntry(className.substring(className.lastIndexOf('.') + 1), ids));
+        }
+    }
+
+    /**
+     * Delete data from the filesystem in the order in which the related batches were passed to
+     * {@link #deleteInstances(String, Collection)}.
+     * @param deletionInstance a deletion instance for deleting files
+     */
+    public void deleteFiles(Deletion deletionInstance) {
+        for (final Map.Entry<String, Collection<Long>> deletionBatch : deletionLog) {
+            final ImmutableSetMultimap.Builder<String, Long> targets = ImmutableSetMultimap.builder();
+            targets.putAll(deletionBatch.getKey(), deletionBatch.getValue());
+            deletionInstance.deleteFiles(targets.build());
+        }
+        deletionLog.clear();
     }
 
     @Override

--- a/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
+++ b/src/main/java/omero/cmd/graphs/BaseGraphTraversalProcessor.java
@@ -19,6 +19,7 @@
 
 package omero.cmd.graphs;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -30,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Maps;
 
 import ome.model.core.OriginalFile;
 import ome.model.core.Pixels;
@@ -76,7 +76,7 @@ public abstract class BaseGraphTraversalProcessor implements GraphTraversal.Proc
             LOGGER.warn("not all the objects of type " + className + " could be deleted");
         }
         if (DELETION_CLASS_NAMES.contains(className)) {
-            deletionLog.add(Maps.immutableEntry(className.substring(className.lastIndexOf('.') + 1), ids));
+            deletionLog.add(new AbstractMap.SimpleImmutableEntry<>(className.substring(className.lastIndexOf('.') + 1), ids));
         }
     }
 

--- a/src/main/java/omero/cmd/graphs/Chgrp2I.java
+++ b/src/main/java/omero/cmd/graphs/Chgrp2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -89,6 +89,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, ReadOnlyStatus.IsAware,
     private Helper helper;
     private GraphHelper graphHelper;
     private GraphTraversal graphTraversal;
+    private InternalProcessor internalProcessor;
 
     private GraphTraversal.PlanExecutor unlinker;
     private GraphTraversal.PlanExecutor processor;
@@ -168,8 +169,10 @@ public class Chgrp2I extends Chgrp2 implements IRequest, ReadOnlyStatus.IsAware,
 
         graphPolicy.registerPredicate(new GroupPredicate(securityRoles));
 
+        internalProcessor = new InternalProcessor(requiredAbilities);
+
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, requiredAbilities, graphPolicy, graphPolicyAdjusters,
-                aclVoter, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
+                aclVoter, graphPathBean, unnullable, internalProcessor, dryRun);
 
         if (isChgrpPrivilege) {
             graphTraversal.setOwnsAll();
@@ -231,7 +234,7 @@ public class Chgrp2I extends Chgrp2 implements IRequest, ReadOnlyStatus.IsAware,
                     (Entry<SetMultimap<String, Long>, SetMultimap<String, Long>>) object;
             if (!dryRun) {
                 try {
-                    deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
+                    internalProcessor.deleteFiles(deletionInstance);
                 } catch (Exception e) {
                     helper.cancel(new ERR(), e, "file-delete-fail");
                 }

--- a/src/main/java/omero/cmd/graphs/Chmod2I.java
+++ b/src/main/java/omero/cmd/graphs/Chmod2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -92,6 +92,7 @@ public class Chmod2I extends Chmod2 implements IRequest, ReadOnlyStatus.IsAware,
     private Helper helper;
     private GraphHelper graphHelper;
     private GraphTraversal graphTraversal;
+    private InternalProcessor internalProcessor;
     private Set<Long> acceptableGroups;
 
     private GraphTraversal.PlanExecutor unlinker;
@@ -165,8 +166,10 @@ public class Chmod2I extends Chmod2 implements IRequest, ReadOnlyStatus.IsAware,
 
         graphPolicy.registerPredicate(new GroupPredicate(securityRoles));
 
+        internalProcessor = new InternalProcessor();
+
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, graphPathBean, unnullable, new InternalProcessor(), dryRun);
+                aclVoter, graphPathBean, unnullable, internalProcessor, dryRun);
 
         graphPolicyAdjusters = null;
     }
@@ -255,7 +258,7 @@ public class Chmod2I extends Chmod2 implements IRequest, ReadOnlyStatus.IsAware,
                     (Entry<SetMultimap<String, Long>, SetMultimap<String, Long>>) object;
             if (!dryRun) {
                 try {
-                    deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
+                    internalProcessor.deleteFiles(deletionInstance);
                 } catch (Exception e) {
                     helper.cancel(new ERR(), e, "file-delete-fail");
                 }

--- a/src/main/java/omero/cmd/graphs/Chown2I.java
+++ b/src/main/java/omero/cmd/graphs/Chown2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -105,6 +105,7 @@ public class Chown2I extends Chown2 implements IRequest, ReadOnlyStatus.IsAware,
     private Helper helper;
     private GraphHelper graphHelper;
     private GraphTraversal graphTraversal;
+    private InternalProcessor internalProcessor;
     private Set<Long> acceptableGroupsFrom;
     private Set<Long> acceptableGroupsTo;
 
@@ -199,8 +200,10 @@ public class Chown2I extends Chown2 implements IRequest, ReadOnlyStatus.IsAware,
         graphPolicy.registerPredicate(new GroupPredicate(securityRoles));
         graphPolicy.registerPredicate(new PermissionsPredicate());
 
+        internalProcessor = new InternalProcessor(requiredAbilities);
+
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, graphPathBean, unnullable, new InternalProcessor(requiredAbilities), dryRun);
+                aclVoter, graphPathBean, unnullable, internalProcessor, dryRun);
 
         if (isChownPrivilege) {
             graphTraversal.setOwnsAll();
@@ -354,7 +357,7 @@ public class Chown2I extends Chown2 implements IRequest, ReadOnlyStatus.IsAware,
                     (Entry<SetMultimap<String, Long>, SetMultimap<String, Long>>) object;
             if (!dryRun) {
                 try {
-                    deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result.getValue()));
+                    internalProcessor.deleteFiles(deletionInstance);
                 } catch (Exception e) {
                     helper.cancel(new ERR(), e, "file-delete-fail");
                 }

--- a/src/main/java/omero/cmd/graphs/Delete2I.java
+++ b/src/main/java/omero/cmd/graphs/Delete2I.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -80,6 +80,7 @@ public class Delete2I extends Delete2 implements IRequest, ReadOnlyStatus.IsAwar
     private Helper helper;
     private GraphHelper graphHelper;
     private GraphTraversal graphTraversal;
+    private InternalProcessor internalProcessor;
 
     private GraphTraversal.PlanExecutor unlinker;
     private GraphTraversal.PlanExecutor processor;
@@ -133,8 +134,10 @@ public class Delete2I extends Delete2 implements IRequest, ReadOnlyStatus.IsAwar
 
         graphPolicy = IgnoreTypePolicy.getIgnoreTypePolicy(graphPolicy, graphHelper.getClassesFromNames(typesToIgnore));
 
+        internalProcessor = new InternalProcessor();
+
         graphTraversal = graphHelper.prepareGraphTraversal(childOptions, REQUIRED_ABILITIES, graphPolicy, graphPolicyAdjusters,
-                aclVoter, graphPathBean, unnullable, new InternalProcessor(), dryRun);
+                aclVoter, graphPathBean, unnullable, internalProcessor, dryRun);
 
         graphPolicyAdjusters = null;
     }
@@ -197,7 +200,7 @@ public class Delete2I extends Delete2 implements IRequest, ReadOnlyStatus.IsAwar
             final SetMultimap<String, Long> result = (SetMultimap<String, Long>) object;
             if (!dryRun) {
                 try {
-                    deletionInstance.deleteFiles(GraphUtil.trimPackageNames(result));
+                    internalProcessor.deleteFiles(deletionInstance);
                 } catch (Exception e) {
                     helper.cancel(new ERR(), e, "file-delete-fail");
                 }

--- a/src/main/java/omero/cmd/graphs/GraphUtil.java
+++ b/src/main/java/omero/cmd/graphs/GraphUtil.java
@@ -84,7 +84,9 @@ public class GraphUtil {
      * and the ordering of the values preserved.
      * @param entriesByFullName a multimap
      * @return a new multimap with the same contents, except for the package name having been trimmed off each key
+     * @deprecated no longer used internally
      */
+    @Deprecated
     static <X> SetMultimap<String, X> trimPackageNames(SetMultimap<String, X> entriesByFullName) {
         final SetMultimap<String, X> entriesBySimpleName = LinkedHashMultimap.create();
         for (final Map.Entry<String, Collection<X>> entriesForOneClass : entriesByFullName.asMap().entrySet()) {

--- a/src/test/java/omero/cmd/graphs/GraphUtilTest.java
+++ b/src/test/java/omero/cmd/graphs/GraphUtilTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.SetMultimap;
  * @author m.t.b.carroll@dundee.ac.uk
  * @since 5.1.0
  */
+@Deprecated
 @Test
 public class GraphUtilTest {
 


### PR DESCRIPTION
https://github.com/openmicroscopy/openmicroscopy/pull/3751 and https://github.com/ome/omero-server/pull/14 carefully order file deletions. The need for that latest PR was detected by the `_fs_dir_delete` database trigger however the need for this PR is probably being concealed by [[trello] repo file deletion fails silently](https://trello.com/c/IpCarIFh/362-repo-file-deletion-fails-silently). This PR aims to ensure that the deletions from the underlying filesystem occur in the same order as from the database. This may become more of an issue when data deletion more commonly includes directories due to https://github.com/openmicroscopy/management_tools/pull/921 and its like which the extra-keen may wish to use for thorough testing.

To test, try deleting complex data like SPW and watch for regressions in what is deleted from the binary repository. In normal OMERO usage thumbnails, image files, etc. should be deleted exactly as before.