### PR TITLE
Reduce use of Guava in file path handling.

### DIFF
--- a/src/main/java/ome/formats/importer/ImportLibrary.java
+++ b/src/main/java/ome/formats/importer/ImportLibrary.java
@@ -21,6 +21,7 @@ package ome.formats.importer;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -90,7 +91,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 
 import Ice.Current;
 
@@ -588,7 +588,7 @@ public class ImportLibrary implements IObservable
                 @Override
                 public Map.Entry<Integer, String> call() throws Exception {
                     final String checksum = uploadFile(proc, srcFiles, fileIndex, checksumProviderFactory, estimator, buf.get());
-                    return Maps.immutableEntry(fileIndex, checksum);
+                    return new AbstractMap.SimpleImmutableEntry<>(fileIndex, checksum);
                 }});
         }
         final ExecutorCompletionService<Map.Entry<Integer, String>> threadQueue = new ExecutorCompletionService<>(threadPool);

--- a/src/main/java/ome/services/blitz/repo/path/ClientFilePathTransformer.java
+++ b/src/main/java/ome/services/blitz/repo/path/ClientFilePathTransformer.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 

--- a/src/main/java/ome/services/blitz/repo/path/FsFile.java
+++ b/src/main/java/ome/services/blitz/repo/path/FsFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2012-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -26,11 +26,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 
 /**
  * An analog of {@link File} representing an FS repository file-path.
@@ -150,7 +149,7 @@ public class FsFile {
      * @return the transformed path
      */
     public FsFile transform(Function<String, String> componentTransformer) {
-        return new FsFile(Lists.transform(this.components, componentTransformer));
+        return new FsFile(this.components.stream().map(componentTransformer).collect(Collectors.toList()));
     }
     
     /**

--- a/src/main/java/ome/services/blitz/repo/path/MakePathComponentSafe.java
+++ b/src/main/java/ome/services/blitz/repo/path/MakePathComponentSafe.java
@@ -19,7 +19,7 @@
 
 package ome.services.blitz.repo.path;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * @author m.t.b.carroll@dundee.ac.uk

--- a/src/main/java/ome/services/blitz/repo/path/ServerFilePathTransformer.java
+++ b/src/main/java/ome/services/blitz/repo/path/ServerFilePathTransformer.java
@@ -21,8 +21,7 @@ package ome.services.blitz.repo.path;
 
 import java.io.File;
 import java.io.IOException;
-
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /**
  * Transform between repository {@link FsFile} path and server-local {@link File}.

--- a/src/main/java/ome/services/blitz/util/ChecksumAlgorithmMapper.java
+++ b/src/main/java/ome/services/blitz/util/ChecksumAlgorithmMapper.java
@@ -23,8 +23,8 @@ import static omero.rtypes.rstring;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 
 import ome.util.checksum.ChecksumType;

--- a/src/main/java/omero/cmd/fs/OriginalMetadataRequestI.java
+++ b/src/main/java/omero/cmd/fs/OriginalMetadataRequestI.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -54,7 +55,6 @@ import omero.constants.namespaces.NSCOMPANIONFILE;
 import omero.util.IceMapper;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 
 /**
  * Original metadata loader, handling both pre-FS and post-FS data.
@@ -255,8 +255,9 @@ public class OriginalMetadataRequestI extends OriginalMetadataRequest implements
         if (equalsIndex == null) {
             return null;
         } else {
-            return Maps.immutableEntry(keyValue.substring(0, equalsIndex).trim(),
-                                       keyValue.substring(equalsIndex + 1).trim());
+            return new AbstractMap.SimpleImmutableEntry<>(
+                    keyValue.substring(0, equalsIndex).trim(),
+                    keyValue.substring(equalsIndex + 1).trim());
         }
     }
 

--- a/src/test/java/ome/services/blitz/test/utests/ServerFilePathTransformerTest.java
+++ b/src/test/java/ome/services/blitz/test/utests/ServerFilePathTransformerTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.function.Function;
 
 import ome.services.blitz.repo.path.ClientFilePathTransformer;
 import ome.services.blitz.repo.path.ServerFilePathTransformer;
@@ -36,8 +37,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.google.common.base.Function;
 
 /**
  * @author m.t.b.carroll@dundee.ac.uk


### PR DESCRIPTION
This should not change behavior because it simply uses the standard library where we can easily avoid resorting to a third-party library. Server should work just as before.