### PR TITLE
Reduce use of Guava in model graph code.

### DIFF
--- a/src/main/java/omero/cmd/graphs/Chgrp2I.java
+++ b/src/main/java/omero/cmd/graphs/Chgrp2I.java
@@ -27,13 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import ome.system.EventContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;

--- a/src/main/java/omero/cmd/graphs/ChildOptionI.java
+++ b/src/main/java/omero/cmd/graphs/ChildOptionI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -22,13 +22,12 @@ package omero.cmd.graphs;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 
 import ome.model.IObject;
@@ -100,12 +99,12 @@ public class ChildOptionI extends ChildOption {
         if (CollectionUtils.isEmpty(includeType)) {
             typeInclusions = ImmutableSet.of();
         } else {
-            typeInclusions = ImmutableSet.copyOf(Collections2.transform(includeType, getClassFromName));
+            typeInclusions = ImmutableSet.copyOf(includeType.stream().map(getClassFromName).collect(Collectors.toSet()));
         }
         if (CollectionUtils.isEmpty(excludeType)) {
             typeExclusions = ImmutableSet.of();
         } else {
-            typeExclusions = ImmutableSet.copyOf(Collections2.transform(excludeType, getClassFromName));
+            typeExclusions = ImmutableSet.copyOf(excludeType.stream().map(getClassFromName).collect(Collectors.toSet()));
         }
 
         if (typeInclusions.isEmpty() && typeExclusions.isEmpty()) {
@@ -140,12 +139,12 @@ public class ChildOptionI extends ChildOption {
         if (CollectionUtils.isEmpty(includeNs)) {
             if (CollectionUtils.isEmpty(excludeNs)) {
                 /* there is no adjustment to make, not even for any default namespaces */
-                isTargetNamespace = Predicates.alwaysTrue();
+                isTargetNamespace = x -> true;
             } else {
                 final ImmutableSet<String> nsExclusions = ImmutableSet.copyOf(excludeNs);
                 isTargetNamespace = new Predicate<String>() {
                     @Override
-                    public boolean apply(String namespace) {
+                    public boolean test(String namespace) {
                         return !nsExclusions.contains(namespace);
                     }
                 };
@@ -155,7 +154,7 @@ public class ChildOptionI extends ChildOption {
                 final ImmutableSet<String> nsInclusions = ImmutableSet.copyOf(includeNs);
                 isTargetNamespace = new Predicate<String>() {
                     @Override
-                    public boolean apply(String namespace) {
+                    public boolean test(String namespace) {
                         return nsInclusions.contains(namespace);
                     }
                 };
@@ -186,7 +185,7 @@ public class ChildOptionI extends ChildOption {
      * @return if child objects that are annotations in this namespace are affected by this child option
      */
     public boolean isTargetNamespace(String namespace) {
-        return isTargetNamespace.apply(namespace);
+        return isTargetNamespace.test(namespace);
     }
 
     /**

--- a/src/main/java/omero/cmd/graphs/ChildOptionsPolicy.java
+++ b/src/main/java/omero/cmd/graphs/ChildOptionsPolicy.java
@@ -19,6 +19,7 @@
 
 package omero.cmd.graphs;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +31,6 @@ import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import ome.model.IObject;
@@ -81,7 +81,7 @@ public class ChildOptionsPolicy {
                             cachedNamespace = namespace;
                             namespaceCache.put(namespace, cachedNamespace);
                         }
-                        objectNamespaces.put(Maps.immutableEntry(realClass, id), cachedNamespace);
+                        objectNamespaces.put(new AbstractMap.SimpleImmutableEntry<>(realClass, id), cachedNamespace);
                     }
                 }
                 super.noteDetails(session, object, realClass, id);
@@ -95,7 +95,7 @@ public class ChildOptionsPolicy {
              */
             private boolean isTargetNamespace(ChildOptionI childOption, IObject object) {
                 if (object instanceof Annotation) {
-                    final Entry<String, Long> classAndId = Maps.immutableEntry(object.getClass().getName(), object.getId());
+                    final Entry<String, Long> classAndId = new AbstractMap.SimpleImmutableEntry<>(object.getClass().getName(), object.getId());
                     return childOption.isTargetNamespace(objectNamespaces.get(classAndId));
                 } else {
                     return true;

--- a/src/main/java/omero/cmd/graphs/Chmod2I.java
+++ b/src/main/java/omero/cmd/graphs/Chmod2I.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import ome.system.EventContext;
 import org.hibernate.Session;
@@ -33,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/omero/cmd/graphs/Chown2I.java
+++ b/src/main/java/omero/cmd/graphs/Chown2I.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import ome.system.EventContext;
 import org.apache.commons.collections.CollectionUtils;
@@ -37,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/src/main/java/omero/cmd/graphs/Delete2I.java
+++ b/src/main/java/omero/cmd/graphs/Delete2I.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;

--- a/src/main/java/omero/cmd/graphs/DiskUsageI.java
+++ b/src/main/java/omero/cmd/graphs/DiskUsageI.java
@@ -20,6 +20,7 @@
 package omero.cmd.graphs;
 
 import java.io.File;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,7 +39,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.google.common.collect.SetMultimap;
 
 import ome.api.IQuery;
@@ -107,77 +107,77 @@ public class DiskUsageI extends DiskUsage implements IRequest, ReadOnlyStatus.Is
     static {
         final ImmutableMultimap.Builder<String, Map.Entry<String, String>> builder = ImmutableMultimap.builder();
 
-        builder.put("Project", Maps.immutableEntry("Dataset",
+        builder.put("Project", new AbstractMap.SimpleImmutableEntry<>("Dataset",
                 "SELECT child.id FROM ProjectDatasetLink WHERE parent.id IN (:ids)"));
-        builder.put("Dataset", Maps.immutableEntry("Image",
+        builder.put("Dataset", new AbstractMap.SimpleImmutableEntry<>("Image",
                 "SELECT child.id FROM DatasetImageLink WHERE parent.id IN (:ids)"));
-        builder.put("Folder", Maps.immutableEntry("Image",
+        builder.put("Folder", new AbstractMap.SimpleImmutableEntry<>("Image",
                 "SELECT child.id FROM FolderImageLink WHERE parent.id IN (:ids)"));
-        builder.put("Folder", Maps.immutableEntry("Roi",
+        builder.put("Folder", new AbstractMap.SimpleImmutableEntry<>("Roi",
                 "SELECT child.id FROM FolderRoiLink WHERE parent.id IN (:ids)"));
-        builder.put("Folder", Maps.immutableEntry("Folder",
+        builder.put("Folder", new AbstractMap.SimpleImmutableEntry<>("Folder",
                 "SELECT id FROM Folder WHERE parentFolder.id IN (:ids)"));
-        builder.put("Screen", Maps.immutableEntry("Plate",
+        builder.put("Screen", new AbstractMap.SimpleImmutableEntry<>("Plate",
                 "SELECT child.id FROM ScreenPlateLink WHERE parent.id IN (:ids)"));
-        builder.put("Plate", Maps.immutableEntry("Well",
+        builder.put("Plate", new AbstractMap.SimpleImmutableEntry<>("Well",
                 "SELECT id FROM Well WHERE plate.id IN (:ids)"));
-        builder.put("Plate", Maps.immutableEntry("PlateAcquisition",
+        builder.put("Plate", new AbstractMap.SimpleImmutableEntry<>("PlateAcquisition",
                 "SELECT id FROM PlateAcquisition WHERE plate.id IN (:ids)"));
-        builder.put("PlateAcquisition", Maps.immutableEntry("WellSample",
+        builder.put("PlateAcquisition", new AbstractMap.SimpleImmutableEntry<>("WellSample",
                 "SELECT id FROM WellSample WHERE plateAcquisition.id IN (:ids)"));
-        builder.put("Well", Maps.immutableEntry("WellSample",
+        builder.put("Well", new AbstractMap.SimpleImmutableEntry<>("WellSample",
                 "SELECT id FROM WellSample WHERE well.id IN (:ids)"));
-        builder.put("Well", Maps.immutableEntry("Reagent",
+        builder.put("Well", new AbstractMap.SimpleImmutableEntry<>("Reagent",
                 "SELECT child.id FROM WellReagentLink WHERE parent.id IN (:ids)"));
-        builder.put("WellSample", Maps.immutableEntry("Image",
+        builder.put("WellSample", new AbstractMap.SimpleImmutableEntry<>("Image",
                 "SELECT image.id FROM WellSample WHERE id IN (:ids)"));
-        builder.put("Image", Maps.immutableEntry("Pixels",
+        builder.put("Image", new AbstractMap.SimpleImmutableEntry<>("Pixels",
                 "SELECT id FROM Pixels WHERE image.id IN (:ids)"));
-        builder.put("Pixels", Maps.immutableEntry("Thumbnail",
+        builder.put("Pixels", new AbstractMap.SimpleImmutableEntry<>("Thumbnail",
                 "SELECT id FROM Thumbnail WHERE pixels.id IN (:ids)"));
-        builder.put("Pixels", Maps.immutableEntry("OriginalFile",
+        builder.put("Pixels", new AbstractMap.SimpleImmutableEntry<>("OriginalFile",
                 "SELECT parent.id FROM PixelsOriginalFileMap WHERE child.id IN (:ids)"));
-        builder.put("Pixels", Maps.immutableEntry("Channel",
+        builder.put("Pixels", new AbstractMap.SimpleImmutableEntry<>("Channel",
                 "SELECT id FROM Channel WHERE pixels.id IN (:ids)"));
-        builder.put("Pixels", Maps.immutableEntry("PlaneInfo",
+        builder.put("Pixels", new AbstractMap.SimpleImmutableEntry<>("PlaneInfo",
                 "SELECT id FROM PlaneInfo WHERE pixels.id IN (:ids)"));
-        builder.put("Channel", Maps.immutableEntry("LogicalChannel",
+        builder.put("Channel", new AbstractMap.SimpleImmutableEntry<>("LogicalChannel",
                 "SELECT logicalChannel.id FROM Channel WHERE id IN (:ids)"));
-        builder.put("Image", Maps.immutableEntry("Fileset",
+        builder.put("Image", new AbstractMap.SimpleImmutableEntry<>("Fileset",
                 "SELECT fileset.id FROM Image WHERE id IN (:ids)"));
-        builder.put("Fileset", Maps.immutableEntry("Job",
+        builder.put("Fileset", new AbstractMap.SimpleImmutableEntry<>("Job",
                 "SELECT child.id FROM FilesetJobLink WHERE parent.id IN (:ids)"));
-        builder.put("Job", Maps.immutableEntry("OriginalFile",
+        builder.put("Job", new AbstractMap.SimpleImmutableEntry<>("OriginalFile",
                 "SELECT child.id FROM JobOriginalFileLink WHERE parent.id IN (:ids)"));
-        builder.put("Fileset", Maps.immutableEntry("Image",
+        builder.put("Fileset", new AbstractMap.SimpleImmutableEntry<>("Image",
                 "SELECT id FROM Image WHERE fileset.id IN (:ids)"));
-        builder.put("Fileset", Maps.immutableEntry("FilesetEntry",
+        builder.put("Fileset", new AbstractMap.SimpleImmutableEntry<>("FilesetEntry",
                 "SELECT id FROM FilesetEntry WHERE fileset.id IN (:ids)"));
-        builder.put("FilesetEntry", Maps.immutableEntry("OriginalFile",
+        builder.put("FilesetEntry", new AbstractMap.SimpleImmutableEntry<>("OriginalFile",
                 "SELECT originalFile.id FROM FilesetEntry WHERE id IN (:ids)"));
-        builder.put("Annotation", Maps.immutableEntry("OriginalFile",
+        builder.put("Annotation", new AbstractMap.SimpleImmutableEntry<>("OriginalFile",
                 "SELECT file.id FROM FileAnnotation WHERE id IN (:ids)"));
-        builder.put("Image", Maps.immutableEntry("Roi",
+        builder.put("Image", new AbstractMap.SimpleImmutableEntry<>("Roi",
                 "SELECT id FROM Roi WHERE image.id IN (:ids)"));
-        builder.put("Roi", Maps.immutableEntry("Shape",
+        builder.put("Roi", new AbstractMap.SimpleImmutableEntry<>("Shape",
                 "SELECT id FROM Shape WHERE roi.id IN (:ids)"));
-        builder.put("Roi", Maps.immutableEntry("OriginalFile",
+        builder.put("Roi", new AbstractMap.SimpleImmutableEntry<>("OriginalFile",
                 "SELECT source.id FROM Roi WHERE id IN (:ids)"));
-        builder.put("Image", Maps.immutableEntry("Instrument",
+        builder.put("Image", new AbstractMap.SimpleImmutableEntry<>("Instrument",
                 "SELECT instrument.id FROM Image WHERE id IN (:ids)"));
-        builder.put("Instrument", Maps.immutableEntry("Detector",
+        builder.put("Instrument", new AbstractMap.SimpleImmutableEntry<>("Detector",
                 "SELECT id FROM Detector WHERE instrument.id IN (:ids)"));
-        builder.put("Instrument", Maps.immutableEntry("Dichroic",
+        builder.put("Instrument", new AbstractMap.SimpleImmutableEntry<>("Dichroic",
                 "SELECT id FROM Dichroic WHERE instrument.id IN (:ids)"));
-        builder.put("Instrument", Maps.immutableEntry("Filter",
+        builder.put("Instrument", new AbstractMap.SimpleImmutableEntry<>("Filter",
                 "SELECT id FROM Filter WHERE instrument.id IN (:ids)"));
-        builder.put("Instrument", Maps.immutableEntry("LightSource",
+        builder.put("Instrument", new AbstractMap.SimpleImmutableEntry<>("LightSource",
                 "SELECT id FROM LightSource WHERE instrument.id IN (:ids)"));
-        builder.put("Instrument", Maps.immutableEntry("Objective",
+        builder.put("Instrument", new AbstractMap.SimpleImmutableEntry<>("Objective",
                 "SELECT id FROM Objective WHERE instrument.id IN (:ids)"));
-        builder.put("Dichroic", Maps.immutableEntry("LightPath",
+        builder.put("Dichroic", new AbstractMap.SimpleImmutableEntry<>("LightPath",
                 "SELECT id FROM LightPath WHERE dichroic.id IN (:ids)"));
-        builder.put("LogicalChannel", Maps.immutableEntry("LightPath",
+        builder.put("LogicalChannel", new AbstractMap.SimpleImmutableEntry<>("LightPath",
                 "SELECT lightPath.id FROM LogicalChannel WHERE id IN (:ids)"));
 
         TRAVERSAL_QUERIES = builder.build();

--- a/src/main/java/omero/cmd/graphs/DuplicateI.java
+++ b/src/main/java/omero/cmd/graphs/DuplicateI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2017 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -20,6 +20,7 @@
 package omero.cmd.graphs;
 
 import java.lang.reflect.Method;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.commons.beanutils.NestedNullException;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -40,15 +43,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 
@@ -183,7 +182,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                 return SkipTailPolicy.getSkipTailPolicy(graphPolicy,
                         new Predicate<Class<? extends IObject>>() {
                     @Override
-                    public boolean apply(Class<? extends IObject> modelObject) {
+                    public boolean test(Class<? extends IObject> modelObject) {
                         final Inclusion classification = classifier.getClass(modelObject);
                         return classification == Inclusion.REFERENCE || classification == Inclusion.IGNORE;
                     }});
@@ -336,7 +335,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                         }
                         /* copy original property value to duplicate, creating new instances of collections */
                         final Object value = PropertyUtils.getProperty(original, property);
-                        final Object duplicateValue = GraphUtil.copyComplexValue(Functions.constant(null), value);
+                        final Object duplicateValue = GraphUtil.copyComplexValue(x -> null, value);
                         PropertyUtils.setProperty(duplicate, property, duplicateValue);
                     }
                 }
@@ -363,7 +362,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                         originalClass = original.getClass().getName();
                     }
                     final Long originalId = ((IObject) original).getId();
-                    return originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
+                    return originalClassIdToDuplicates.get(new AbstractMap.SimpleImmutableEntry<>(originalClass, originalId));
                 } else {
                     return null;
                 }
@@ -519,7 +518,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                                     }
                                     final Long originalId = ((IObject) original).getId();
                                     final IObject duplicate =
-                                            originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
+                                            originalClassIdToDuplicates.get(new AbstractMap.SimpleImmutableEntry<>(originalClass, originalId));
                                     if (duplicate == null) {
                                         return null;
                                     }
@@ -550,7 +549,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                                 }
                                 final Long originalId = ((IObject) original).getId();
                                 final IObject duplicate =
-                                        originalClassIdToDuplicates.get(Maps.immutableEntry(originalClass, originalId));
+                                        originalClassIdToDuplicates.get(new AbstractMap.SimpleImmutableEntry<>(originalClass, originalId));
                                 if (duplicate == null) {
                                     return null;
                                 }
@@ -822,7 +821,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                     }
                     final String originalClass = Hibernate.getClass(original).getName();
                     final Long originalId = original.getId();
-                    originalClassIdToDuplicates.put(Maps.immutableEntry(originalClass, originalId), duplicate);
+                    originalClassIdToDuplicates.put(new AbstractMap.SimpleImmutableEntry<>(originalClass, originalId), duplicate);
                     originalsToDuplicates.put(original, duplicate);
                 }
             }

--- a/src/main/java/omero/cmd/graphs/FindChildrenI.java
+++ b/src/main/java/omero/cmd/graphs/FindChildrenI.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/omero/cmd/graphs/FindParentsI.java
+++ b/src/main/java/omero/cmd/graphs/FindParentsI.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/omero/cmd/graphs/GraphHelper.java
+++ b/src/main/java/omero/cmd/graphs/GraphHelper.java
@@ -26,11 +26,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.context.ApplicationContext;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.SetMultimap;

--- a/src/main/java/omero/cmd/graphs/GraphUtil.java
+++ b/src/main/java/omero/cmd/graphs/GraphUtil.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -43,9 +45,7 @@ import ome.services.graphs.GraphTraversal.Processor;
 import ome.services.graphs.ModelObjectSequencer;
 import omero.cmd.GraphModify2;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.base.Predicate;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.SetMultimap;
 
@@ -375,7 +375,7 @@ public class GraphUtil {
     public static Predicate<Class<? extends IObject>> getPredicateFromClasses(final Iterable<Class<? extends IObject>> matchTypes) {
         return new Predicate<Class<? extends IObject>>() {
             @Override
-            public boolean apply(Class<? extends IObject> subjectType) {
+            public boolean test(Class<? extends IObject> subjectType) {
                 for (final Class<? extends IObject> matchType : matchTypes) {
                     if (matchType.isAssignableFrom(subjectType)) {
                         return true;

--- a/src/main/java/omero/cmd/graphs/IgnoreTypePolicy.java
+++ b/src/main/java/omero/cmd/graphs/IgnoreTypePolicy.java
@@ -20,12 +20,11 @@
 package omero.cmd.graphs;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Predicate;
 
 import ome.model.IObject;
 import ome.services.graphs.GraphPolicy;
@@ -55,7 +54,7 @@ public class IgnoreTypePolicy {
 
         final Predicate<Class<? extends IObject>> isTypeToIgnore = new Predicate<Class<? extends IObject>>() {
             @Override
-            public boolean apply(Class<? extends IObject> objectClass) {
+            public boolean test(Class<? extends IObject> objectClass) {
                 for (final Class<? extends IObject> typeToIgnore : typesToIgnore) {
                     if (typeToIgnore.isAssignableFrom(objectClass)) {
                         return true;
@@ -68,7 +67,7 @@ public class IgnoreTypePolicy {
         return new BaseGraphPolicyAdjuster(graphPolicyToAdjust) {
             @Override
             protected boolean isAdjustedBeforeReview(Details object) {
-                if (object.action == GraphPolicy.Action.EXCLUDE && isTypeToIgnore.apply(object.subject.getClass())) {
+                if (object.action == GraphPolicy.Action.EXCLUDE && isTypeToIgnore.test(object.subject.getClass())) {
                     object.action = GraphPolicy.Action.OUTSIDE;
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("ignoring all objects of its type, so making " + object);

--- a/src/main/java/omero/cmd/graphs/SkipHeadI.java
+++ b/src/main/java/omero/cmd/graphs/SkipHeadI.java
@@ -23,11 +23,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;

--- a/src/main/java/omero/cmd/graphs/SkipHeadPolicy.java
+++ b/src/main/java/omero/cmd/graphs/SkipHeadPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 University of Dundee & Open Microscopy Environment.
+ * Copyright (C) 2014-2019 University of Dundee & Open Microscopy Environment.
  * All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -23,15 +23,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.SetMultimap;
 
@@ -82,14 +82,14 @@ public class SkipHeadPolicy {
         };
 
         final ImmutableSet<Class <? extends IObject>> startFromClasses =
-                ImmutableSet.copyOf(Collections2.transform(startFrom, getClassFromName));
+                ImmutableSet.copyOf(startFrom.stream().map(getClassFromName).collect(Collectors.toSet()));
 
         final Predicate<IObject> isStartFrom = new Predicate<IObject>() {
             private final Predicate<Class<? extends IObject>> tester = GraphUtil.getPredicateFromClasses(startFromClasses);
 
             @Override
-            public boolean apply(IObject subject) {
-                return tester.apply(subject.getClass());
+            public boolean test(IObject subject) {
+                return tester.test(subject.getClass());
             }
         };
 
@@ -124,7 +124,7 @@ public class SkipHeadPolicy {
             @Override
             public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject,
                     Map<String, Set<Details>> linkedTo, Set<String> notNullable, boolean isErrorRules) throws GraphException {
-                if (rootObject.action == startAction && isStartFrom.apply(rootObject.subject)) {
+                if (rootObject.action == startAction && isStartFrom.test(rootObject.subject)) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("deferring review of " + rootObject);
                     }

--- a/src/main/java/omero/cmd/graphs/SkipTailPolicy.java
+++ b/src/main/java/omero/cmd/graphs/SkipTailPolicy.java
@@ -23,12 +23,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Predicate;
 
 import ome.model.IObject;
 import ome.services.graphs.GraphException;
@@ -83,7 +82,7 @@ public class SkipTailPolicy {
             @Override
             public final Set<Details> review(Map<String, Set<Details>> linkedFrom, Details rootObject,
                     Map<String, Set<Details>> linkedTo, Set<String> notNullable, boolean isErrorRules) throws GraphException {
-                if (isSkipClass.apply(rootObject.subject.getClass())) {
+                if (isSkipClass.test(rootObject.subject.getClass())) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("halting review at " + rootObject);
                     }
@@ -95,7 +94,7 @@ public class SkipTailPolicy {
                     final Iterator<Details> changesIterator = changes.iterator();
                     while (changesIterator.hasNext()) {
                         final Details change = changesIterator.next();
-                        if (change.action == Action.INCLUDE && isSkipClass.apply(change.subject.getClass())) {
+                        if (change.action == Action.INCLUDE && isSkipClass.test(change.subject.getClass())) {
                             if (LOGGER.isDebugEnabled()) {
                                 LOGGER.debug("forestalling policy-based change " + change);
                             }

--- a/src/main/java/omero/cmd/graphs/WrappableRequest.java
+++ b/src/main/java/omero/cmd/graphs/WrappableRequest.java
@@ -21,12 +21,11 @@ package omero.cmd.graphs;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import ome.services.graphs.GraphPolicy;
 import omero.cmd.IRequest;
 import omero.cmd.Response;
-
-import com.google.common.base.Function;
 
 /**
  * Requests that can be wrapped by a {@link SkipHeadI} request.


### PR DESCRIPTION
This should not change behavior because it simply uses the standard library where we can now easily avoid resorting to a third-party library. Server should work just as before. Fine to leave the PR open awhile to give more chance to notice unexpected side-effects.