### PR TITLE
Generate ice doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 5E6DA83306132997
   - sudo apt-add-repository "deb http://zeroc.com/download/apt/ubuntu14.04 stable main"
   - sudo apt-get update -q
-  - sudo apt-get install libzeroc-ice-java -y
+  - sudo apt-get install libzeroc-ice-java zeroc-ice-utils -y
   - sudo pip install https://github.com/ome/zeroc-ice-py-ubuntu1404/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-none-linux_x86_64.whl
   - sudo ln -s /usr/local/bin/slice2py /usr/bin/slice2py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ install:
 script:
   - ./gradlew publishToMavenLocal -x javadoc
   - ./gradlew test
+  - test -f build/distributions/omero-blitz-*-icedoc.zip
+  - test -f build/distributions/omero-blitz-*-python.zip

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.openmicroscopy.dsl" version "5.5.0-m6"
     id "org.openmicroscopy.blitz" version "5.5.0-m5"
     id "org.openmicroscopy.project" version "5.5.0-m5"
-    id "org.openmicroscopy.gradle.ice-builder.slice" version "1.5.0-m4"
+    id "org.openmicroscopy.gradle.ice-builder.slice" version "1.5.0-SNAPSHOT"
 }
 
 group = "org.openmicroscopy"
@@ -22,6 +22,7 @@ java {
 
 ext {
     pythonOutputDir = "$buildDir/toArchive/python"
+    iceOutputDir = "$buildDir/toArchive/icedoc"
     generatedDir = "${blitz.outputDir.get()}"
     generatedSliceDir = "${generatedDir}/slice"
 }
@@ -177,6 +178,14 @@ compileSlice.dependsOn "copySliceFiles"
 
 // Set compileJava to additionally depend on "splitJava"
 compileJava.dependsOn "generateJava"
+
+task compileIcedoc(type: com.zeroc.gradle.icebuilder.slice.IceDocsTask, dependsOn: "compileSlice") {
+    source = "src/main/slice"
+    outputDir = file("${iceOutputDir}")
+    includeDirs = files("${generatedSliceDir}", "src/main/slice")
+    header = file("src/main/resources/header.txt")
+    footer = file("src/main/resources/footer.txt")
+}
 
 // Add publish functionality
 apply from: "publish.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "org.openmicroscopy.dsl" version "5.5.0-m6"
     id "org.openmicroscopy.blitz" version "5.5.0-m5"
     id "org.openmicroscopy.project" version "5.5.0-m5"
-    id "org.openmicroscopy.gradle.ice-builder.slice" version "1.5.0-SNAPSHOT"
+    id "org.openmicroscopy.gradle.ice-builder.slice" version "1.5.0-m5"
 }
 
 group = "org.openmicroscopy"

--- a/build.gradle
+++ b/build.gradle
@@ -180,9 +180,9 @@ compileSlice.dependsOn "copySliceFiles"
 compileJava.dependsOn "generateJava"
 
 task compileIcedoc(type: com.zeroc.gradle.icebuilder.slice.IceDocsTask, dependsOn: "compileSlice") {
-    source = "src/main/slice"
     outputDir = file("${iceOutputDir}")
     includeDirs = files("${generatedSliceDir}", "src/main/slice")
+    sourceDirs = files("${generatedSliceDir}", "src/main/slice")
     header = file("src/main/resources/header.txt")
     footer = file("src/main/resources/footer.txt")
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -14,7 +14,7 @@ publishing {
         blitzPython(MavenPublication) {
             artifact pythonZip
         }
-        serverIcedoc(MavenPublication) {
+        blitzIcedoc(MavenPublication) {
             artifact zipIcedoc
         }
     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -4,10 +4,18 @@ task pythonZip(type: Zip) {
     from pythonOutputDir
 }
 
+task zipIcedoc(type: Zip) {
+    archiveClassifier.set("icedoc")
+    from compileIcedoc
+}
+
 publishing {
     publications {
         blitzPython(MavenPublication) {
             artifact pythonZip
+        }
+        serverIcedoc(MavenPublication) {
+            artifact zipIcedoc
         }
     }
 }

--- a/src/main/resources/footer.txt
+++ b/src/main/resources/footer.txt
@@ -1,3 +1,2 @@
-       <div id="version-bottom"><p>Version: @VERSION@</p><div/>
     </body>
 </html>

--- a/src/main/resources/header.txt
+++ b/src/main/resources/header.txt
@@ -17,6 +17,5 @@ TITLE
           <div id="banner">
              <img src="https://downloads.openmicroscopy.org/resources/ome_docs_trac_banner.png" alt="OME-XML">
           </div>
-          <div id="version-top"><p>Version: @VERSION@</p></div>
           <div id="doc-name-right" style="position: absolute;top: 117px;right: 25px;font-size: 24px;font-weight: bold;"><b>OmeroBlitz API</b></div>
        </div>


### PR DESCRIPTION
Minimum set of changes required to build the slice doc
Generation of the doc is tested by travis 
The commit 31035d8 will be removed when https://github.com/ome/ice-builder-gradle/pull/9 is merged and the repository tagged

In travis
* Check that the icedoc tasks are run
* Check that zip is created

Test locally:
* run ``gradle clean publishToMavenLocal`` (add ``-x javadoc`` to be quicker)