### PR TITLE
Add TableCloserI for stateful cleanup (fix #56)

### DIFF
--- a/src/main/java/ome/services/blitz/impl/SharedResourcesI.java
+++ b/src/main/java/ome/services/blitz/impl/SharedResourcesI.java
@@ -405,8 +405,8 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
 
         sf.allow(tablePrx);
         register(tablePrx);
+        new TableCloserI(sf, tablePrx, sessionedID("Table"));
         return tablePrx;
-
     }
 
     // Check job

--- a/src/main/java/ome/services/blitz/impl/SharedResourcesI.java
+++ b/src/main/java/ome/services/blitz/impl/SharedResourcesI.java
@@ -405,8 +405,10 @@ public class SharedResourcesI extends AbstractCloseableAmdServant implements
 
         sf.allow(tablePrx);
         register(tablePrx);
-        new TableCloserI(sf, tablePrx, sessionedID("Table"));
-        return tablePrx;
+        TableCloserI closer = new TableCloserI(sf, tablePrx, sessionedID("Table"));
+        closer.setApplicationContext(this.ctx);
+        closer.setHolder(holder);
+        return closer.getProxy();
     }
 
     // Check job

--- a/src/main/java/ome/services/blitz/impl/TableCloserI.java
+++ b/src/main/java/ome/services/blitz/impl/TableCloserI.java
@@ -65,6 +65,8 @@ public class TableCloserI extends AbstractCloseableAmdServant
     protected void preClose(Current current) throws Throwable {
         try {
             this.table.close();
+        } catch (Ice.ObjectNotExistException onee) {
+            // already closed, e.g. by table.delete()
         } finally {
             sf.unregisterServant(tableId);
         }

--- a/src/main/java/ome/services/blitz/impl/TableCloserI.java
+++ b/src/main/java/ome/services/blitz/impl/TableCloserI.java
@@ -5,58 +5,163 @@
 
 package ome.services.blitz.impl;
 
-import java.util.UUID;
-
-import omero.api.*;
-import omero.grid.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import Ice.Current;
+import omero.RType;
+import omero.ServerError;
+import omero.api.StatefulServiceInterfacePrx;
+import omero.api.StatefulServiceInterfacePrxHelper;
+import omero.api._StatefulServiceInterfaceOperations;
+import omero.api._StatefulServiceInterfaceTie;
+import omero.grid.*;
+import omero.model.OriginalFile;
+
+import java.util.Map;
 
 /**
  * Blitz-specific wrapper for table proxies to facilitate the
  * cleanup of files on session exit.
  */
-public class TableCloserI extends AbstractAmdServant
-    implements _StatefulServiceInterfaceOperations {
+public class TableCloserI extends AbstractCloseableAmdServant
+    implements _StatefulServiceInterfaceOperations, _TableOperations {
 
-    private static Logger log = LoggerFactory.getLogger(TableCloserI.class);
-
+    /**
+     * Proxy to the remote table which should only be used internally to this instance.
+     */
     private final TablePrx table;
 
+    /**
+     * Proxy to this instance which will be passed to clients.
+     */
+    private final TablePrx self;
+
+    private final Ice.Identity tableId;
+
+    private final Ice.Identity statefulId;
+
     private final ServiceFactoryI sf;
-
-    private final Ice.Identity id;
-
-    private final StatefulServiceInterfacePrx self;
 
     public TableCloserI(ServiceFactoryI sf, TablePrx tablePrx, Ice.Identity id)
             throws omero.ServerError {
         super(null, null);
         this.table = tablePrx;
         this.sf = sf;
-        this.id = id;
-        this.self = StatefulServiceInterfacePrxHelper.uncheckedCast(
-                sf.registerServant(this.id, new _StatefulServiceInterfaceTie(this)));
-        sf.allow(this.self);
+        this.tableId = id;
+        this.statefulId = new Ice.Identity(id.name + "-closer", id.category);
+        this.self = TablePrxHelper.uncheckedCast(
+                sf.registerServant(tableId, new _TableTie(this)));
+        StatefulServiceInterfacePrx closer = StatefulServiceInterfacePrxHelper.uncheckedCast(
+                sf.registerServant(statefulId, new _StatefulServiceInterfaceTie(this)));
+        sf.allow(self);
+        sf.allow(closer);
     }
 
-    public StatefulServiceInterfacePrx getProxy() {
+    public TablePrx getProxy() {
         return self;
+    }
+
+    // CLOSEABLE
+
+    @Override
+    protected void preClose(Current current) throws Throwable {
+        try {
+            this.table.close();
+        } finally {
+            sf.unregisterServant(tableId);
+        }
+    }
+
+    @Override
+    protected void postClose(Current current) {
+
     }
 
     // DELEGATION
 
-    @Override
-    public void close_async(AMD_StatefulServiceInterface_close __cb, Current __current) {
-        try {
-            table.close();
-            __cb.ice_response();
-        } catch (Exception e) {
-            __cb.ice_exception(e);
-        } catch (Throwable t) {
-            __cb.ice_exception(new RuntimeException("unknown throwable", t));
+    private Map<String, String> check(Current __current) {
+        if (__current != null) {
+            return __current.ctx;
         }
+        return null;
     }
+
+    @Override
+    public OriginalFile getOriginalFile(Current __current) throws ServerError {
+        return table.getOriginalFile(check(__current));
+    }
+
+    @Override
+    public Column[] getHeaders(Current __current) throws ServerError {
+        return table.getHeaders(check(__current));
+    }
+
+    @Override
+    public long getNumberOfRows(Current __current) throws ServerError {
+        return table.getNumberOfRows(check(__current));
+    }
+
+    @Override
+    public long[] getWhereList(String condition, Map<String, RType> variables, long start, long stop, long step, Current __current) throws ServerError {
+        return table.getWhereList(condition, variables, start, stop, step, check(__current));
+    }
+
+    @Override
+    public Data readCoordinates(long[] rowNumbers, Current __current) throws ServerError {
+        return table.readCoordinates(rowNumbers, check(__current));
+    }
+
+    @Override
+    public Data read(long[] colNumbers, long start, long stop, Current __current) throws ServerError {
+        return table.read(colNumbers, start, stop, check(__current));
+    }
+
+    @Override
+    public Data slice(long[] colNumbers, long[] rowNumbers, Current __current) throws ServerError {
+        return table.slice(colNumbers, rowNumbers, check(__current));
+    }
+
+    @Override
+    public void addData(Column[] cols, Current __current) throws ServerError {
+        table.addData(cols, check(__current));
+    }
+
+    @Override
+    public void update(Data modifiedData, Current __current) throws ServerError {
+        table.update(modifiedData, check(__current));
+    }
+
+    @Override
+    public Map<String, RType> getAllMetadata(Current __current) throws ServerError {
+        return table.getAllMetadata(check(__current));
+    }
+
+    @Override
+    public RType getMetadata(String key, Current __current) throws ServerError {
+        return table.getMetadata(key, check(__current));
+    }
+
+    @Override
+    public void setAllMetadata(Map<String, RType> dict, Current __current) throws ServerError {
+        table.setAllMetadata(dict, check(__current));
+    }
+
+    @Override
+    public void setMetadata(String key, RType value, Current __current) throws ServerError {
+        table.setMetadata(key, value, check(__current));
+    }
+
+    @Override
+    public void initialize(Column[] cols, Current __current) throws ServerError {
+        table.initialize(cols, check(__current));
+    }
+
+    @Override
+    public int addColumn(Column col, Current __current) throws ServerError {
+        return table.addColumn(col, check(__current));
+    }
+
+    @Override
+    public void delete(Current __current) throws ServerError {
+        table.delete(check(__current));
+    }
+
 }

--- a/src/main/java/ome/services/blitz/impl/TableCloserI.java
+++ b/src/main/java/ome/services/blitz/impl/TableCloserI.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2019 University of Dundee. All rights reserved.
+ *   Use is subject to license terms supplied in LICENSE.txt
+ */
+
+package ome.services.blitz.impl;
+
+import java.util.UUID;
+
+import omero.api.*;
+import omero.grid.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import Ice.Current;
+
+/**
+ * Blitz-specific wrapper for table proxies to facilitate the
+ * cleanup of files on session exit.
+ */
+public class TableCloserI extends AbstractAmdServant
+    implements _StatefulServiceInterfaceOperations {
+
+    private static Logger log = LoggerFactory.getLogger(TableCloserI.class);
+
+    private final TablePrx table;
+
+    private final ServiceFactoryI sf;
+
+    private final Ice.Identity id;
+
+    private final StatefulServiceInterfacePrx self;
+
+    public TableCloserI(ServiceFactoryI sf, TablePrx tablePrx, Ice.Identity id)
+            throws omero.ServerError {
+        super(null, null);
+        this.table = tablePrx;
+        this.sf = sf;
+        this.id = id;
+        this.self = StatefulServiceInterfacePrxHelper.uncheckedCast(
+                sf.registerServant(this.id, new _StatefulServiceInterfaceTie(this)));
+        sf.allow(this.self);
+    }
+
+    public StatefulServiceInterfacePrx getProxy() {
+        return self;
+    }
+
+    // DELEGATION
+
+    @Override
+    public void close_async(AMD_StatefulServiceInterface_close __cb, Current __current) {
+        try {
+            table.close();
+            __cb.ice_response();
+        } catch (Exception e) {
+            __cb.ice_exception(e);
+        } catch (Throwable t) {
+            __cb.ice_exception(new RuntimeException("unknown throwable", t));
+        }
+    }
+}


### PR DESCRIPTION
TablePrx instances from the Tables-0 process are not registered in a
session as a stateful service. Clients can't know or discover that
they are open. The TableCloser implements StatefulServiceInterface to
allow clients to call close().

Tested via this script:

```
$ cat t.py
import omero
import omero.grid
c=omero.client("localhost")
c.createSession("root", "omero")
try:
    s = c.sf.sharedResources()
    t = s.newTable(1, "foo.h5")
    l = omero.grid.LongColumn("foo")
    t.initialize([l])
    services = c.getStatefulServices()
    print services[0].ice_ids()
    services[0].close()
finally:
    c.__del__()
```
which prints:
```
$ PYTHONPATH=lib/python python t.py
['::Ice::Object', '::omero::api::ServiceInterface', '::omero::api::StatefulServiceInterface']
```
Opening now to get it into regular testing. ~Additional integration tests will be needed in openmicroscopy/openmicroscopy.~ This PR prevents calling `getOriginalFile()` after `close()` has been called, which has clearly been proven throughout the code base.