### PR TITLE
Client should enable "*_anon" cipher algs, not just "anon".

### DIFF
--- a/src/main/java/omero/client.java
+++ b/src/main/java/omero/client.java
@@ -211,9 +211,10 @@ public class client {
             boolean isChanged = false;
             for (String algorithm : value.split(",")) {
                 algorithm = algorithm.trim();
+                final String algorithmLower = algorithm.toLowerCase();
                 if (algorithm.isEmpty()) {
                     /* ignore */
-                } else if ("anon".equals(algorithm.toLowerCase())) {
+                } else if (algorithmLower.equals("anon") || algorithmLower.endsWith("_anon")) {
                     isChanged = true;
                 } else {
                     algorithms.add(algorithm);


### PR DESCRIPTION
Attempts to fix the problem with Java clients connecting from Fedora 30. See [[ome-devel] Issues connecting to OMERO](https://lists.openmicroscopy.org.uk/pipermail/ome-devel/2019-June/004386.html).