### PR TITLE
IceSSL.Ciphers: Include default ciphers alongside '(DH_anon.*AES)'

### DIFF
--- a/src/main/java/omero/client.java
+++ b/src/main/java/omero/client.java
@@ -379,7 +379,9 @@ public class client {
         optionallySetProperty(id, "Ice.Default.PreferSecure", "1");
         optionallySetProperty(id, "Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
         optionallySetProperty(id, "IceSSL.Protocols", "tls1");
-        optionallySetProperty(id, "IceSSL.Ciphers", "NONE (DH_anon.*AES)");
+        // This cipher specification includes the default ciphers + anon-DH
+        // ciphers required by OMERO.server in its default configuration.
+        optionallySetProperty(id, "IceSSL.Ciphers", "(DH_anon.*AES)");
         optionallySetProperty(id, "IceSSL.VerifyPeer", "0");
         optionallySetProperty(id, "omero.block_size", Integer
             .toString(omero.constants.DEFAULTBLOCKSIZE.value));


### PR DESCRIPTION
Previously this was 'NONE (DH_anon.*AES)' which prevented use of the default (stronger) ciphers required when certificates are isntalled on the server.

See https://doc.zeroc.com/ice/3.6/property-reference/icessl#id-.IceSSL.*v3.6-Java.2 (IceSSL.Ciphers Java sub-section)