### PR TITLE
import targets: add support for Project

### DIFF
--- a/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
+++ b/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
@@ -19,6 +19,15 @@
 
 package ome.formats.importer.targets;
 
+import static omero.rtypes.rlong;
+import static omero.rtypes.rstring;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
 import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.ImportContainer;
 import omero.api.IQueryPrx;
@@ -29,17 +38,9 @@ import omero.model.ProjectDatasetLink;
 import omero.model.ProjectDatasetLinkI;
 import omero.model.ProjectI;
 import omero.sys.ParametersI;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import static omero.rtypes.rlong;
-import static omero.rtypes.rstring;
 
 /**
  * @since 5.1.2

--- a/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
+++ b/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
@@ -31,7 +31,8 @@ import ome.formats.OMEROMetadataStoreClient;
 import ome.formats.importer.ImportContainer;
 import omero.api.IQueryPrx;
 import omero.api.IUpdatePrx;
-import omero.model.IObject;
+import omero.model.*;
+import static omero.rtypes.rlong;
 import omero.sys.ParametersI;
 
 import org.slf4j.Logger;
@@ -48,12 +49,24 @@ public class ModelImportTarget implements ImportTarget {
      * Valid omero.model classes for model import target.
      */
     private static final List<String> VALID_TYPES = Arrays.asList(
-            "omero.model.Dataset", "omero.model.Screen");
+            "omero.model.Project", "omero.model.Dataset", "omero.model.Screen");
 
     /**
      * omero.model class which can be used for instantiation.
      */
     private Class<? extends IObject> type;
+
+    /**
+     * Object of {@link #type} which is found or created.
+     */
+    private Long id;
+
+    /**
+     * Internal representation of a target deeper in the hierarchy if needed.
+     * For example, if this instance represents a Project, then the subTarget
+     * would be a Dataset.
+     */
+    private ModelImportTarget subTarget;
 
     /**
      * String used for querying the database; must be ome.model based.
@@ -63,8 +76,6 @@ public class ModelImportTarget implements ImportTarget {
     private String simpleName;
 
     private String prefix;
-
-    private Long id;
 
     private String discriminator;
 
@@ -110,10 +121,16 @@ public class ModelImportTarget implements ImportTarget {
     }
 
     public Class<? extends IObject> getObjectType() {
+        if (subTarget != null) {
+            return subTarget.getObjectType();
+        }
         return type;
     }
 
     public Long getObjectId() {
+        if (subTarget != null) {
+            return subTarget.getObjectId();
+        }
         return id;
     }
 
@@ -121,6 +138,18 @@ public class ModelImportTarget implements ImportTarget {
     public IObject load(OMEROMetadataStoreClient client, ImportContainer ic) throws Exception {
         IQueryPrx query = client.getServiceFactory().getQueryService();
         IUpdatePrx update = client.getServiceFactory().getUpdateService();
+
+        if ("Project".equals(simpleName)) {
+            if (!name.contains("/")) {
+                throw new RuntimeException("Project name is missing a '/': " + name);
+            }
+            String[] tokens = name.split("/", 2);
+            name = tokens[0];
+            log.info("Creating sub-target: {}", tokens[1]);
+            subTarget = new ModelImportTarget();
+            subTarget.init(tokens[1]);
+        }
+
         if (discriminator.matches("^[-+%@]?name$")) {
             IObject obj;
             String order = "desc";
@@ -161,6 +190,24 @@ public class ModelImportTarget implements ImportTarget {
         } else {
             log.error("Unknown discriminator {}", discriminator);
             throw new RuntimeException("Unknown discriminator "+discriminator);
+        }
+
+        if (subTarget != null) {
+            log.info("Super-target loaded: {}:{}", simpleName, id);
+            IObject sub = subTarget.load(client, ic);
+            // FIXME: need general method
+            List<List<omero.RType>> rv = query.projection(
+                    "select pdl.id from ProjectDatasetLink pdl where pdl.parent.id = :pid " +
+                    "and pdl.child.id = :did",
+                    new ParametersI().add("pid", rlong(id)).add("did", sub.getId()));
+            if (rv.size() == 0) {
+                ProjectDatasetLink pdl = new ProjectDatasetLinkI();
+                pdl.setParent(new ProjectI(id, false));
+                pdl.setChild(new DatasetI(subTarget.getObjectId(), false));
+                update.saveObject(pdl);
+                log.info("Linked targets");
+            }
+            return sub;
         }
         return query.get(type.getSimpleName(), id);
     }

--- a/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
+++ b/src/main/java/ome/formats/importer/targets/ModelImportTarget.java
@@ -19,7 +19,18 @@
 
 package ome.formats.importer.targets;
 
-import static omero.rtypes.rstring;
+import ome.formats.OMEROMetadataStoreClient;
+import ome.formats.importer.ImportContainer;
+import omero.api.IQueryPrx;
+import omero.api.IUpdatePrx;
+import omero.model.DatasetI;
+import omero.model.IObject;
+import omero.model.ProjectDatasetLink;
+import omero.model.ProjectDatasetLinkI;
+import omero.model.ProjectI;
+import omero.sys.ParametersI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -27,16 +38,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import ome.formats.OMEROMetadataStoreClient;
-import ome.formats.importer.ImportContainer;
-import omero.api.IQueryPrx;
-import omero.api.IUpdatePrx;
-import omero.model.*;
 import static omero.rtypes.rlong;
-import omero.sys.ParametersI;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static omero.rtypes.rstring;
 
 /**
  * @since 5.1.2


### PR DESCRIPTION
A command like:

```
bin/omero import -T Project:name:bar/Dataset:name:foo /tmp/a.fake
```

now loads a sub-target of type `Dataset` internally. The output
from such an import looks like:

```
INFO          ome.formats.importer.ImportConfig - Using import target: Project:name:bar/Dataset:name:foo
INFO   rmats.importer.targets.ModelImportTarget - Creating sub-target: Dataset:name:foo
INFO   rmats.importer.targets.ModelImportTarget - Super-target loaded: Project:303
INFO   rmats.importer.targets.ModelImportTarget - Linked targets
INFO         ome.formats.importer.ImportLibrary - Import target specifies container: Dataset:855
```

see: https://forum.image.sc/t/cli-import-specifiy-project-to-place-dataset/27037/3