### PR TITLE
cleanup and expose import keep alives (see #64)

### DIFF
--- a/src/main/java/ome/formats/OMEROMetadataStoreClient.java
+++ b/src/main/java/ome/formats/OMEROMetadataStoreClient.java
@@ -664,7 +664,7 @@ public class OMEROMetadataStoreClient
 
     /**
      * Initializes the MetadataStore taking string parameters to feed to the
-     * OMERO Blitz client object. Using this method to create either secure
+     * OMERO Blitz client object. Using this method creates either secure
      * or unsecure sessions and sets the user's group to supplied group.
      * When finished with this instance, close all resources via
      * {@link #logout}

--- a/src/main/java/ome/formats/OMEROMetadataStoreClient.java
+++ b/src/main/java/ome/formats/OMEROMetadataStoreClient.java
@@ -229,6 +229,9 @@ public class OMEROMetadataStoreClient
     implements MetadataStore, IMinMaxStore, IObjectContainerStore
 {
 
+    /**
+     * Default time in seconds between calls of the keep alive thread.
+     */
     public static Integer DEFAULT_KEEP_ALIVE = 300;
 
     /** Logger for this class */
@@ -416,6 +419,7 @@ public class OMEROMetadataStoreClient
      * @param keepAliveRate
      *
      *           Schedule in seconds at which the background keep alive ping should be called.
+     *           If null, then no keep alive thread will be started.
      *
      * @throws ServerError
      */

--- a/src/main/java/ome/formats/importer/ImportConfig.java
+++ b/src/main/java/ome/formats/importer/ImportConfig.java
@@ -146,6 +146,7 @@ public class ImportConfig {
 
     public final BoolValue encryptedConnection;
     public final BoolValue autoClose;
+    public final IntValue keepAlive;
 
     public final AnnotationListValue annotations;
     public final DoubleArrayValue userPixels;
@@ -286,6 +287,7 @@ public class ImportConfig {
 
         encryptedConnection = new BoolValue("encryptedConnection", this, true);
         autoClose = new BoolValue("autoClose", this, false);
+        keepAlive = new IntValue("keepAlive", this, 300);
 
         annotations = new AnnotationListValue(
                 "annotations", this, new ArrayList<Annotation>());
@@ -373,10 +375,10 @@ public class ImportConfig {
         OMEROMetadataStoreClient client = new OMEROMetadataStoreClient();
         if (sessionKey.empty()) {
             client.initialize(username.get(), password.get(), hostname.get(),
-                    port.get(), group.get(), encryptedConnection.get());
+                    port.get(), group.get(), encryptedConnection.get(), keepAlive.get());
 
         } else {
-            client.initialize(hostname.get(), port.get(), sessionKey.get(), encryptedConnection.get());
+            client.initialize(hostname.get(), port.get(), sessionKey.get(),encryptedConnection.get(), keepAlive.get());
         }
         return client;
     }

--- a/src/main/java/ome/formats/importer/ImportLibrary.java
+++ b/src/main/java/ome/formats/importer/ImportLibrary.java
@@ -254,9 +254,10 @@ public class ImportLibrary implements IObservable
         if (cka != null) {
             cka.addObserver((observable, event) -> {
                 if (event instanceof ImportEvent.LOGGED_OUT) {
-                    log.info("Initializing log out");
+                    log.debug("Initializing log out");
                     shutdown.set(true);
                     for (ImportCallback cb : callbacks) {
+                        log.debug("Shutting down callback " + cb);
                         cb.shutdown();
                     }
                     if (filesetThreadPool != null) {

--- a/src/main/java/ome/formats/importer/ImportLibrary.java
+++ b/src/main/java/ome/formats/importer/ImportLibrary.java
@@ -249,7 +249,7 @@ public class ImportLibrary implements IObservable
         final Ice.Communicator ic = oa.getCommunicator();
         category = omero.client.getRouter(ic).getCategoryForClient();
 
-        // Propagate a logout from the OMSC to this instances executors
+        // Propagate a logout from the OMSC to this instance's executors
         ClientKeepAlive cka = store.getKeepAlive();
         if (cka != null) {
             cka.addObserver((observable, event) -> {

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -842,7 +842,7 @@ public class CommandLineImporter {
             }
             case 30: {
                 String keepAliveUArg = g.getOptarg();
-                config.keepAlive.set(Integer.valueOf(keepAliveUArg));
+                config.keepAlive.set(Integer.parseInt(keepAliveUArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -424,7 +424,7 @@ public class CommandLineImporter {
             + "\n"
             + "  Background imports:\n"
             + "  -------------------\n\n"
-            + "    --keep-alive            \tFrequency in seconds for pinging the server.\n\n"
+            + "    --keep-alive=SECS       \tFrequency in seconds for pinging the server.\n\n"
             + "    --auto-close            \tClose completed imports immediately.\n\n"
             + "    --minutes-wait=ARG      \tChoose how long the importer will wait on server-side processing.\n"
             + "                            \tARG > 0 implies the number of minutes to wait.\n"
@@ -663,7 +663,7 @@ public class CommandLineImporter {
                                 noUpgradeCheck, qaBaseURL,
                                 outputFormat, encryptedConnection,
                                 parallelUpload, parallelFileset,
-                                readers,
+                                readers, keepAlive,
                                 plateName, plateName2,
                                 plateDescription, plateDescription2,
                                 noThumbnailsDeprecated,

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -424,6 +424,7 @@ public class CommandLineImporter {
             + "\n"
             + "  Background imports:\n"
             + "  -------------------\n\n"
+            + "    --keep-alive            \tFrequency in seconds for pinging the server.\n\n"
             + "    --auto-close            \tClose completed imports immediately.\n\n"
             + "    --minutes-wait=ARG      \tChoose how long the importer will wait on server-side processing.\n"
             + "                            \tARG > 0 implies the number of minutes to wait.\n"
@@ -620,6 +621,8 @@ public class CommandLineImporter {
 
         LongOpt readers =
                 new LongOpt("readers", LongOpt.REQUIRED_ARGUMENT, null, 29);
+        LongOpt keepAlive =
+                new LongOpt("keep-alive", LongOpt.REQUIRED_ARGUMENT, null, 30);
 
         // DEPRECATED OPTIONS
         LongOpt minutesWaitDeprecated =
@@ -835,6 +838,11 @@ public class CommandLineImporter {
                 String parallelUArg = g.getOptarg();
                 log.info("Setting parallel fileset: {}", parallelUArg);
                 config.parallelFileset.set(Integer.valueOf(parallelUArg));
+                break;
+            }
+            case 30: {
+                String keepAliveUArg = g.getOptarg();
+                config.keepAlive.set(Integer.valueOf(keepAliveUArg));
                 break;
             }
             // ADVANCED END ---------------------------------------------------

--- a/src/main/java/ome/formats/importer/cli/ErrorHandler.java
+++ b/src/main/java/ome/formats/importer/cli/ErrorHandler.java
@@ -38,7 +38,11 @@ public class ErrorHandler extends ome.formats.importer.util.ErrorHandler {
     public void onUpdate(IObservable importLibrary, ImportEvent event) {
 
         if (event instanceof IMPORT_DONE) {
-            log.info("Number of errors: " + errors.size());
+            if (errors.size() == 0) {
+                log.debug("Number of errors: " + errors.size());
+            } else {
+                log.info("Number of errors: " + errors.size());
+            }
         }
 
         else if (event instanceof SCANNING) {

--- a/src/main/java/ome/formats/importer/util/ClientKeepAlive.java
+++ b/src/main/java/ome/formats/importer/util/ClientKeepAlive.java
@@ -54,7 +54,7 @@ public class ClientKeepAlive implements Runnable, IObservable
     private static Logger log = LoggerFactory.getLogger(ClientKeepAlive.class);
 
     /** The connector we're trying to keep alive. */
-    private AtomicReference<OMEROMetadataStoreClient> client = new AtomicReference<OMEROMetadataStoreClient>();
+    private AtomicReference<OMEROMetadataStoreClient> client = new AtomicReference<>();
 
     private final ArrayList<IObserver> observers = new ArrayList<IObserver>();
 

--- a/src/main/java/omero/cmd/CmdCallbackI.java
+++ b/src/main/java/omero/cmd/CmdCallbackI.java
@@ -351,9 +351,13 @@ public class CmdCallbackI extends _CmdCallbackDisp {
      * @param closeHandle if the handle should be closed
      */
     public void close(boolean closeHandle) {
-         adapter.remove(id); // OK ADAPTER USAGE
-         if (closeHandle) {
-             handle.close();
-         }
+        try {
+            adapter.remove(id); // OK ADAPTER USAGE
+            if (closeHandle) {
+                handle.close();
+            }
+        } catch (Ice.ObjectAdapterDeactivatedException oade) {
+            // Already shutdown.
+        }
     }
 }


### PR DESCRIPTION
Long-running imports (or imports against servers with artificially short
timeouts) fail and then hang. This makes the import keep alive times
configurable, increases logging, removes synchronization, and enables
keep alives in more situations.

see: https://forum.image.sc/t/keepalive-failed-while-importing-50gb-slide-book-data-file/28588/2