### PR TITLE
Replace all '\[]' slice strings with '&lbrack;'

### DIFF
--- a/src/main/slice/omero/API.ice
+++ b/src/main/slice/omero/API.ice
@@ -128,7 +128,7 @@ module omero {
              * <pre>
              * sf = client.createSession()
              * objs = sf.getSecurityContexts()
-             * old = sf.setSecurityContext(objs\[-1])
+             * old = sf.setSecurityContext(objs&lbrack;-1])
              * </pre>
              *
              **/

--- a/src/main/slice/omero/Scripts.ice
+++ b/src/main/slice/omero/Scripts.ice
@@ -93,7 +93,7 @@ module omero {
          *
          * <pre>
          * a = omero.scripts.String("a")
-         * a.param().values = \["hi", "bye"]
+         * a.param().values = &lbrack;"hi", "bye"]
          * </pre>
          **/
         class Param {
@@ -128,9 +128,9 @@ module omero {
              * param = ...;
              * inputs = ...;
              * if name in inputs:
-             *     value = inputs\[name]
-             * elif param.inputs\[name].useDefault:
-             *     value = param.inputs\[name].prototype
+             *     value = inputs&lbrack;name]
+             * elif param.inputs&lbrack;name].useDefault:
+             *     value = param.inputs&lbrack;name].prototype
              * </pre>
              **/
             bool useDefault;
@@ -250,14 +250,14 @@ module omero {
              * might be displayed as:
              * </p>
              *
+             * <div>
              * <pre>
-             *
-             *  Scale Bar: \[ on/off ]
-             *  ======================
-             *    Color:  \[rgb]
-             *    Size:   \[ 10]
-             *
+             *      Scale Bar: &lbrack; on/off ]
+             *      =====================
+             *        Color:  &lbrack;rgb]
+             *        Size:   &lbrack; 10]
              * </pre>
+             * </div>
              *
              **/
             string grouping;
@@ -302,7 +302,7 @@ module omero {
          *
          * <pre>
          * params = omero.grid.JobParams()
-         * params.authors = \["Andy", "Kathy"]
+         * params.authors = &lbrack;"Andy", "Kathy"]
          * params.version = "0.0.1"
          * params.description = """
          *     Clever way to count to 5
@@ -353,14 +353,14 @@ module omero {
             omero::api::StringArray institutions;
 
             /**
-             * For authors\[i], authorInstitutions\[i] should be
+             * For authors&lbrack;i], authorInstitutions&lbrack;i] should be
              * and array of indexes j such that author i is a member
-             * of authorsInstitutions\[i]\[j].
+             * of authorsInstitutions&lbrack;i]&lbrack;j].
              *
              * Example:
-             *   authors = \["Jane", "Mike"]
-             *   institutions = \["Acme U.", "Private Corp."]
-             *   authorsInstitutions = \[\[1, 2], \[1]]
+             *   authors = &lbrack;"Jane", "Mike"]
+             *   institutions = &lbrack;"Acme U.", "Private Corp."]
+             *   authorsInstitutions = &lbrack;&lbrack;1, 2], &lbrack;1]]
              *
              * which means that Jane is a member of both "Acme U."
              * and "Private Corp." while Mike is only a member of

--- a/src/main/slice/omero/Tables.ice
+++ b/src/main/slice/omero/Tables.ice
@@ -204,8 +204,8 @@ module omero {
              * data = table.slice(None, None)
              * assert len(data.rowNumbers) == table.getNumberOfRows()
              *
-             * data = table.slice(None, \[3,2,1])
-             * assert data.rowNumbers == \[3,2,1]
+             * data = table.slice(None, &lbrack;3,2,1])
+             * assert data.rowNumbers == &lbrack;3,2,1]
              * </pre>
              **/
             idempotent

--- a/src/main/slice/omero/api/Exporter.ice
+++ b/src/main/slice/omero/api/Exporter.ice
@@ -43,7 +43,7 @@ module omero {
          *   // Exporter instances.
          *
          *   long read = 0
-         *   byte\[] buf;
+         *   byte&lbrack;] buf;
          *   while (true) {
          *      buf = e.read(read, 1000000);
          *      // Store to file locally here

--- a/src/main/slice/omero/api/IScript.ice
+++ b/src/main/slice/omero/api/IScript.ice
@@ -25,7 +25,7 @@ module omero {
          * scripts = svc.getScripts()
          *
          * if len(scripts) >= 1:
-         *   script_id = svc.keys()\[-1]
+         *   script_id = svc.keys()&lbrack;-1]
          * else:
          *   script_id = svc.uploadScript('/test/my_script.py', SCRIPT_TEXT)
          *
@@ -74,7 +74,7 @@ module omero {
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
                  *     # First character is a "/" symbol
-                 *     path = script.path.val\[1:\]
+                 *     path = script.path.val&lbrack;1:\]
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
                  * }
@@ -105,7 +105,7 @@ module omero {
                  * scripts = scriptService.getScripts("py")
                  * for script in scripts:
                  *     text = scriptService.getScriptText(script.id.val)
-                 *     path = script.path.val\[1:\] # First symbol is a "/"
+                 *     path = script.path.val&lbrack;1:\] # First symbol is a "/"
                  *     path = path.replace("/",".")
                  *     print "Possible import: %s" % path
                  * }

--- a/src/main/slice/omero/api/ITimeline.ice
+++ b/src/main/slice/omero/api/ITimeline.ice
@@ -32,7 +32,7 @@ module omero {
          * The map return values will be indexed by the short type name above:
          * <i>Project</i>, <i>Image</i>, ... All keys which are passed in the
          * StringSet argument will be included in the returned map, even if
-         * they have no values. A default value of 0 or the empty list \[]
+         * they have no values. A default value of 0 or the empty list &lbrack;]
          * will be used.
          * The only exception to this rule is that the null or empty StringSet
          * implies all valid keys.
@@ -53,8 +53,8 @@ module omero {
          * The methods which take a StringSet and a Parameters object, also
          * have a <i>bool merge</i> argument. This argument defines whether or
          * not the LIMIT applies to each object independently
-         * (<code>\["a","b"] @ 100 == 200</code>) or merges the lists together
-         * chronologically (<code>\["a","b"] @ 100 merged == 100</code>).
+         * (<code>&lbrack;"a","b"] @ 100 == 200</code>) or merges the lists together
+         * chronologically (<code>&lbrack;"a","b"] @ 100 merged == 100</code>).
          *
          * <h4>Time used</h4>
          *
@@ -70,7 +70,7 @@ module omero {
          * {@code
          *     timeline = sf.getTimelineService()
          *     params = ParametersI().page(0,100)
-         *     types = \["Project","Dataset"])
+         *     types = &lbrack;"Project","Dataset"])
          *     map = timeline.getByPeriod(types, params, False)
          * }
          * </pre>

--- a/src/main/slice/omero/api/RenderingEngine.ice
+++ b/src/main/slice/omero/api/RenderingEngine.ice
@@ -273,7 +273,7 @@ module omero {
 
                 /**
                  * Sets the sub-interval of the device space i.e. a discrete
-                 * sub-interval of \[0, 255].
+                 * sub-interval of &lbrack;0, 255].
                  *
                  * @param start The lower bound of the interval.
                  * @param end The upper bound of the interval.

--- a/src/main/slice/omero/cmd/Mail.ice
+++ b/src/main/slice/omero/cmd/Mail.ice
@@ -32,10 +32,10 @@ module omero {
          *  - omero.cmd.SendEmailRequest(subject, body, everyone=True, inactive=True)
          *      sends message to everyone who has email set,
          *      even inactive users
-         *  - omero.cmd.SendEmailRequest(subject, body, groupIds=\[...],
-         *      userIds=\[...] )
+         *  - omero.cmd.SendEmailRequest(subject, body, groupIds=&lbrack;...],
+         *      userIds=&lbrack;...] )
          *      sends email to active members of given groups and selected users
-         *  - extra=\[...] allows to set extra email address if not in DB
+         *  - extra=&lbrack;...] allows to set extra email address if not in DB
          */
          class SendEmailRequest extends Request {
              string subject;


### PR DESCRIPTION
In Python 3, the doc strings of Python modules are
unicode and the initial slash is interpreted as an
invalid escape sequence:

```
target/IceImport.py:22: in load
    __import__(target)
E     File "/py/target/omero_Scripts_ice.py", line 454
E       """
E        ^
E   SyntaxError: invalid escape sequence \[
```

see also: https://github.com/ome/omero-blitz/commit/64222ab24