### PR TITLE
unicode: import 'str' as 'unicode' for Python 3

### DIFF
--- a/src/main/resources/templates/combined.vm
+++ b/src/main/resources/templates/combined.vm
@@ -182,6 +182,11 @@ DECLARATION BLOCK:
 [$jav]    implements ome.model.ModelBased {
 
 Note how the whitespace for the python definitions is important.
+[$pyc] try:
+[$pyc]    unicode
+[$pyc] except NameError:
+[$pyc]    # Python 3: "unicode" is built-in
+[$pyc]    unicode = str
 [$pyc] import Ice
 [$pyc] import IceImport
 [$pyc] import omero


### PR DESCRIPTION
This replaces the no longer extant `types.StringTypes`.