### PR TITLE
TMP: ice version

### DIFF
--- a/src/main/java/omero/client.java
+++ b/src/main/java/omero/client.java
@@ -370,10 +370,14 @@ public class client {
 
         // Strictly necessary for this class to work
         optionallySetProperty(id, "Ice.ImplicitContext", "Shared");
-        optionallySetProperty(id, "Ice.ACM.Client.Timeout",
-                ""+omero.constants.ACMCLIENTTIMEOUT.value);
-        optionallySetProperty(id, "Ice.ACM.Client.Heartbeat", ""+
-                omero.constants.ACMCLIENTHEARTBEAT.value);
+        if (Ice.Util.intVersion() >= 30600) {
+            optionallySetProperty(id, "Ice.ACM.Client.Timeout",
+                    "" + omero.constants.ACMCLIENTTIMEOUT.value);
+            optionallySetProperty(id, "Ice.ACM.Client.Heartbeat", "" +
+                    omero.constants.ACMCLIENTHEARTBEAT.value);
+        } else {
+            optionallySetProperty(id, "Ice.ACM.Client", "0");
+        }
         optionallySetProperty(id, "Ice.CacheMessageBuffers", "0");
         optionallySetProperty(id, "Ice.RetryIntervals", "-1");
         optionallySetProperty(id, "Ice.Default.EndpointSelection", "Ordered");
@@ -388,6 +392,10 @@ public class client {
         optionallySetProperty(id, "omero.block_size", Integer
             .toString(omero.constants.DEFAULTBLOCKSIZE.value));
 
+        if (Ice.Util.intVersion() >= 30500) {
+            optionallySetProperty(id, "Ice.Default.EncodingVersion", "1.0");
+        }
+        
         // Setting MessageSizeMax
         optionallySetProperty(id, "Ice.MessageSizeMax", Integer
             .toString(omero.constants.MESSAGESIZEMAX.value));


### PR DESCRIPTION
While looking at extension in Imaris (which uses a different version of Ice)
it is not possible to connect to omero when the imaris.jar is in the classpath
I temporarily add the check to see if it helps. 