### PR TITLE
Throw early on null tablePrx

### DIFF
--- a/src/main/java/ome/services/blitz/impl/TableCloserI.java
+++ b/src/main/java/ome/services/blitz/impl/TableCloserI.java
@@ -44,6 +44,9 @@ public class TableCloserI extends AbstractCloseableAmdServant
             throws omero.ServerError {
         super(null, null);
         this.table = tablePrx;
+        if (this.table == null) {
+            throw new omero.InternalException(null, null, "null table as argument");
+        }
         this.tableId = id;
         this.statefulId = new Ice.Identity(id.name + "-closer", id.category);
         this.self = TablePrxHelper.uncheckedCast(


### PR DESCRIPTION
An error in the OMERO.tables implementation returned null
proxies. The TableCloser happily took the null leading all
subsequent methods to fail (e.g. `initialize()`). Rather
than checking in each method, null proxies are disallowed.

cf. https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-test-integration/171/testngreports/integration/TableTest/createTable/

```
Exception Ice.UnknownException
Message: (none)

Stacktrace:

    unknown = "java.lang.NullPointerException
               	at ome.services.blitz.impl.TableCloserI.initialize(TableCloserI.java:166)
               	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
               	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
               	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
               	at java.lang.reflect.Method.invoke(Method.java:498)
               	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:333)
               	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:190)
               	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:157)
               	at omero.cmd.CallContext.invoke(CallContext.java:85)
               	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
               	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
               	at com.sun.proxy.$Proxy124.initialize(Unknown Source)
               	at omero.grid._TableTie.initialize(_TableTie.java:126)
               	at omero.grid._TableDisp.___initialize(_TableDisp.java:528)
               	at omero.grid._TableDisp.__dispatch(_TableDisp.java:689)
               	at IceInternal.Incoming.invoke(Incoming.java:221)
               	at Ice.ConnectionI.invokeAll(ConnectionI.java:2536)
               	at Ice.ConnectionI.dispatch(ConnectionI.java:1145)
               	at Ice.ConnectionI.message(ConnectionI.java:1056)
               	at IceInternal.ThreadPool.run(ThreadPool.java:395)
               	at IceInternal.ThreadPool.access$300(ThreadPool.java:12)
               	at IceInternal.ThreadPool$EventHandlerThread.run(ThreadPool.java:832)
               	at java.lang.Thread.run(Thread.java:748)
               "
	at IceInternal.AsyncResultI.__wait(AsyncResultI.java:276)
	at omero.grid.TablePrxHelper.end_initialize(TablePrxHelper.java:2046)
```