### PR TITLE
model: Handle infinities in generated conversions

### DIFF
--- a/src/main/java/omero/model/ElectricPotentialI.java
+++ b/src/main/java/omero/model/ElectricPotentialI.java
@@ -784,13 +784,17 @@ public class ElectricPotentialI extends ElectricPotential implements ModelBased 
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/ElectricPotentialI.java
+++ b/src/main/java/omero/model/ElectricPotentialI.java
@@ -768,18 +768,36 @@ public class ElectricPotentialI extends ElectricPotential implements ModelBased 
     * Copy constructor that converts the given {@link omero.model.ElectricPotential}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public ElectricPotentialI(ElectricPotential value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsElectricPotential sourceUnit = value.getUnit();
+       final UnitsElectricPotential targetUnit = UnitsElectricPotential.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsElectricPotential targetUnit = UnitsElectricPotential.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/ElectricPotentialI.java
+++ b/src/main/java/omero/model/ElectricPotentialI.java
@@ -785,12 +785,13 @@ public class ElectricPotentialI extends ElectricPotential implements ModelBased 
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/FrequencyI.java
+++ b/src/main/java/omero/model/FrequencyI.java
@@ -785,12 +785,13 @@ public class FrequencyI extends Frequency implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/FrequencyI.java
+++ b/src/main/java/omero/model/FrequencyI.java
@@ -768,18 +768,36 @@ public class FrequencyI extends Frequency implements ModelBased {
     * Copy constructor that converts the given {@link omero.model.Frequency}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public FrequencyI(Frequency value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsFrequency sourceUnit = value.getUnit();
+       final UnitsFrequency targetUnit = UnitsFrequency.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsFrequency targetUnit = UnitsFrequency.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/FrequencyI.java
+++ b/src/main/java/omero/model/FrequencyI.java
@@ -784,13 +784,17 @@ public class FrequencyI extends Frequency implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/LengthI.java
+++ b/src/main/java/omero/model/LengthI.java
@@ -1446,13 +1446,17 @@ public class LengthI extends Length implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/LengthI.java
+++ b/src/main/java/omero/model/LengthI.java
@@ -1447,12 +1447,13 @@ public class LengthI extends Length implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/LengthI.java
+++ b/src/main/java/omero/model/LengthI.java
@@ -1430,18 +1430,36 @@ public class LengthI extends Length implements ModelBased {
     * Copy constructor that converts the given {@link omero.model.Length}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public LengthI(Length value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsLength sourceUnit = value.getUnit();
+       final UnitsLength targetUnit = UnitsLength.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsLength targetUnit = UnitsLength.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/PowerI.java
+++ b/src/main/java/omero/model/PowerI.java
@@ -784,13 +784,17 @@ public class PowerI extends Power implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/PowerI.java
+++ b/src/main/java/omero/model/PowerI.java
@@ -785,12 +785,13 @@ public class PowerI extends Power implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/PowerI.java
+++ b/src/main/java/omero/model/PowerI.java
@@ -768,18 +768,36 @@ public class PowerI extends Power implements ModelBased {
     * Copy constructor that converts the given {@link omero.model.Power}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public PowerI(Power value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsPower sourceUnit = value.getUnit();
+       final UnitsPower targetUnit = UnitsPower.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsPower targetUnit = UnitsPower.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/PressureI.java
+++ b/src/main/java/omero/model/PressureI.java
@@ -1445,12 +1445,13 @@ public class PressureI extends Pressure implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/PressureI.java
+++ b/src/main/java/omero/model/PressureI.java
@@ -1444,13 +1444,17 @@ public class PressureI extends Pressure implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/TemperatureI.java
+++ b/src/main/java/omero/model/TemperatureI.java
@@ -241,12 +241,13 @@ public class TemperatureI extends Temperature implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/java/omero/model/TemperatureI.java
+++ b/src/main/java/omero/model/TemperatureI.java
@@ -224,18 +224,36 @@ public class TemperatureI extends Temperature implements ModelBased {
     * Copy constructor that converts the given {@link omero.model.Temperature}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public TemperatureI(Temperature value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsTemperature sourceUnit = value.getUnit();
+       final UnitsTemperature targetUnit = UnitsTemperature.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsTemperature targetUnit = UnitsTemperature.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/TemperatureI.java
+++ b/src/main/java/omero/model/TemperatureI.java
@@ -240,13 +240,17 @@ public class TemperatureI extends Temperature implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/TimeI.java
+++ b/src/main/java/omero/model/TimeI.java
@@ -924,18 +924,36 @@ public class TimeI extends Time implements ModelBased {
     * Copy constructor that converts the given {@link omero.model.Time}
     * based on the given enum string.
     *
+    * If either the source or the target unit is null or if no conversion
+    * is possible between the two types (e.g. PIXELS), an
+    * {@link IllegalArgumentException} will be thrown. If the conversion
+    * results in an overflow, a {@link BigResult} will be thrown, unless
+    * the input value was already Infinite or NaN, in which case that will
+    * be the return value.
+    *
     * @param target String representation of the CODE enum
+    * @throws IllegalArgumentException if the source or target unit
+    *         is null or an unconvertible type (e.g. PIXELS)
+    * @throws BigResult if the conversion leads to an infinite or NaN result
     */
     public TimeI(Time value, String target) throws BigResult {
-       String source = value.getUnit().toString();
+
+       final UnitsTime sourceUnit = value.getUnit();
+       final UnitsTime targetUnit = UnitsTime.valueOf(target);
+       if (sourceUnit == null || targetUnit == null) {
+           throw new IllegalArgumentException(String.format(
+                       "conversion impossible from %s to %s",
+                       sourceUnit, targetUnit));
+       }
+
+       final String source = value.getUnit().toString();
        if (target.equals(source)) {
            setValue(value.getValue());
            setUnit(value.getUnit());
-        } else {
-            UnitsTime targetUnit = UnitsTime.valueOf(target);
-            Conversion conversion = conversions.get(value.getUnit()).get(targetUnit);
+       } else {
+            final Conversion conversion = conversions.get(sourceUnit).get(targetUnit);
             if (conversion == null) {
-                throw new RuntimeException(String.format(
+                throw new IllegalArgumentException(String.format(
                     "%f %s cannot be converted to %s",
                         value.getValue(), value.getUnit(), target));
             }

--- a/src/main/java/omero/model/TimeI.java
+++ b/src/main/java/omero/model/TimeI.java
@@ -940,13 +940,17 @@ public class TimeI extends Time implements ModelBased {
                         value.getValue(), value.getUnit(), target));
             }
             double orig = value.getValue();
-            BigDecimal big = conversion.convert(orig);
-            double converted = big.doubleValue();
-            if (Double.isInfinite(converted)) {
-                throw new BigResult(big,
-                        "Failed to convert " + source + ":" + target);
+            double converted = orig;
+            if (Double.isInfinite(orig)) {
+                // Do nothing. Use orig
+            } else {
+                BigDecimal big = conversion.convert(orig);
+                converted = big.doubleValue();
+                if (Double.isInfinite(converted)) {
+                    throw new BigResult(big,
+                            "Failed to convert " + source + ":" + target);
+                }
             }
-
             setValue(converted);
             setUnit(targetUnit);
        }

--- a/src/main/java/omero/model/TimeI.java
+++ b/src/main/java/omero/model/TimeI.java
@@ -941,12 +941,13 @@ public class TimeI extends Time implements ModelBased {
             }
             double orig = value.getValue();
             double converted = orig;
-            if (Double.isInfinite(orig)) {
+            if (!Double.isFinite(orig)) {
+                // Infinite or NaN
                 // Do nothing. Use orig
             } else {
                 BigDecimal big = conversion.convert(orig);
                 converted = big.doubleValue();
-                if (Double.isInfinite(converted)) {
+                if (!Double.isFinite(converted)) {
                     throw new BigResult(big,
                             "Failed to convert " + source + ":" + target);
                 }

--- a/src/main/slice/omero/model/ElectricPotential.ice
+++ b/src/main/slice/omero/model/ElectricPotential.ice
@@ -32,15 +32,15 @@ module omero {
        * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
-       * can be found on the table itself (e.g. detectorSettings.voltage
-       * and detectorSettings.voltageUnit).
-       */
+       * can be found on the table itself (e.g. detectorSettings.volatage
+       * and detectorSettings.volatageUnit).
+       **/
     ["protected"] class ElectricPotential
     {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsElectricPotential unit;
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsElectricPotential} enum.
-       */
+       **/
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsElectricPotential} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       */
+       **/
       omero::model::enums::UnitsElectricPotential getUnit();
 
       void setUnit(omero::model::enums::UnitsElectricPotential unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       */
+       **/
       string getSymbol();
 
       ElectricPotential copy();

--- a/src/main/slice/omero/model/ElectricPotential.ice
+++ b/src/main/slice/omero/model/ElectricPotential.ice
@@ -32,8 +32,8 @@ module omero {
        * an {@link omero.model.IObject} implementation and as such does
        * not have an ID value. Instead, the entire object is embedded
        * into the containing class, so that the value and unit rows
-       * can be found on the table itself (e.g. detectorSettings.volatage
-       * and detectorSettings.volatageUnit).
+       * can be found on the table itself (e.g. detectorSettings.voltage
+       * and detectorSettings.voltageUnit).
        **/
     ["protected"] class ElectricPotential
     {

--- a/src/main/slice/omero/model/Frequency.ice
+++ b/src/main/slice/omero/model/Frequency.ice
@@ -34,13 +34,13 @@ module omero {
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. detectorSettings.readOutRate
        * and detectorSettings.readOutRateUnit).
-       */
+       **/
     ["protected"] class Frequency
     {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsFrequency unit;
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsFrequency} enum.
-       */
+       **/
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsFrequency} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       */
+       **/
       omero::model::enums::UnitsFrequency getUnit();
 
       void setUnit(omero::model::enums::UnitsFrequency unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       */
+       **/
       string getSymbol();
 
       Frequency copy();

--- a/src/main/slice/omero/model/Length.ice
+++ b/src/main/slice/omero/model/Length.ice
@@ -34,13 +34,13 @@ module omero {
        * into the containing class, so that the value and unit rows
        * can be found on the table itself (e.g. pixels.physicalSizeX
        * and pixels.physicalSizeXUnit).
-       */
+       **/
     ["protected"] class Length
     {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsLength unit;
@@ -49,7 +49,7 @@ module omero {
        * Actual value for this unit-based field. The interpretation of
        * the value is only possible along with the
        * {@link omero.model.enums.UnitsLength} enum.
-       */
+       **/
       double getValue();
 
       void setValue(double value);
@@ -58,7 +58,7 @@ module omero {
        * {@link omero.model.enums.UnitsLength} instance which is an
        * {@link omero.model.IObject}
        * meaning that its ID is sufficient for identifying equality.
-       */
+       **/
       omero::model::enums::UnitsLength getUnit();
 
       void setUnit(omero::model::enums::UnitsLength unit);
@@ -66,7 +66,7 @@ module omero {
       /**
        * Returns the possibly unicode representation of the ""unit""
        * value for display.
-       */
+       **/
       string getSymbol();
 
       Length copy();

--- a/src/main/slice/omero/model/Power.ice
+++ b/src/main/slice/omero/model/Power.ice
@@ -40,7 +40,7 @@ module omero {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsPower unit;

--- a/src/main/slice/omero/model/Pressure.ice
+++ b/src/main/slice/omero/model/Pressure.ice
@@ -40,7 +40,7 @@ module omero {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsPressure unit;

--- a/src/main/slice/omero/model/Temperature.ice
+++ b/src/main/slice/omero/model/Temperature.ice
@@ -40,7 +40,7 @@ module omero {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsTemperature unit;

--- a/src/main/slice/omero/model/Time.ice
+++ b/src/main/slice/omero/model/Time.ice
@@ -40,7 +40,7 @@ module omero {
 
       /**
        * PositiveFloat value
-       */
+       **/
       double value;
 
       omero::model::enums::UnitsTime unit;


### PR DESCRIPTION
If an input is an infinity, then do not perform the conversion. Throw InvalidArgumentException if nulls, PIXELS, or other unconvertible source/target pairs are passed.

see:
 - https://github.com/ome/ome-units/pull/7
 - https://github.com/ome/omero-gateway-java/pull/15#issuecomment-533590026

cc: @dominikl @jburel @mtbc 