### PR TITLE
Expand user session creation abilities

### DIFF
--- a/src/main/java/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
+++ b/src/main/java/omero/cmd/admin/UpdateSessionTimeoutRequestI.java
@@ -153,12 +153,13 @@ public class UpdateSessionTimeoutRequestI extends UpdateSessionTimeoutRequest
         }
 
         boolean isAdmin = current.getCurrentEventContext().isCurrentUserAdmin();
-        if (!isAdmin && maxUserTimeToLive != 0
+        if (!isAdmin && maxUserTimeToLive != 0 && timeToLive != null
                 && timeToLive.getValue() > maxUserTimeToLive) {
             timeToLive = omero.rtypes.rlong(maxUserTimeToLive);
             helper.info("Attempt to modify timeToLive beyond maximum");
         }
-        if (!isAdmin && timeToIdle.getValue() > maxUserTimeToIdle) {
+        if (!isAdmin && timeToIdle != null
+                && timeToIdle.getValue() > maxUserTimeToIdle) {
             timeToIdle = omero.rtypes.rlong(maxUserTimeToIdle);
             helper.info("Attempt to modify timeToIdle beyond maximum");
         }

--- a/src/main/resources/ome/services/blitz-servantDefinitions.xml
+++ b/src/main/resources/ome/services/blitz-servantDefinitions.xml
@@ -399,6 +399,8 @@
       <constructor-arg ref="currentDetails"/>
       <constructor-arg ref="sessionManager"/>
       <constructor-arg ref="securitySystem"/>
+      <constructor-arg value="${omero.sessions.max_user_time_to_live}"/>
+      <constructor-arg value="${omero.sessions.max_user_time_to_idle}"/>
      <property name="iceCommunicator" ref="Ice.Communicator"/>
   </bean>
 


### PR DESCRIPTION
A system wide, configurable maximum time to idle and time to live is now
in place.  Regular users are allowed to create new sessions with
timeouts up to these limits.  The previous limits were 10x the default
time to idle and time to live and those are now the default configured
values.

Furthermore, it is now possible to pass an "omero.agent" as part of call
context to set the user agent on sessions created using the session
service.  For example:

    createUserSession(0, 600000, 'test', {'omero.agent': 'my agent'})

Finally, the following properties have been exposed to the via the
configuration service so that a user may make predictable and informed
choices during session creation:

 * `omero.sessions.timeout`
 * `omero.sessions.maximum`
 * `omero.sessions.max_user_time_to_idle`
 * `omero.sessions.max_user_time_to_live`