### PR TITLE
unit test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,10 +73,14 @@ if (slice.iceVersion.contains("3.7")) {
 }
 
 test {
+    testLogging {
+        events "passed", "skipped", "failed", "standardOut", "standardError"
+    }
     // enable TestNG support (default is JUnit)
     useTestNG() {
         suites "src/test/resources/unit.testng.xml"
     }
+    dependsOn cleanTest
 }
 
 dsl {


### PR DESCRIPTION
display test output in console and do not cache
Check that the output is displayed in the console every time
``gradle test`` is run