### PR TITLE
Implement setROIName in OMEROMetadataStoreClient

### DIFF
--- a/src/main/java/ome/formats/OMEROMetadataStoreClient.java
+++ b/src/main/java/ome/formats/OMEROMetadataStoreClient.java
@@ -6685,7 +6685,8 @@ public class OMEROMetadataStoreClient
     @Override
     public void setROIName(String name, int ROIIndex)
     {
-        ignoreMissing("setROIName", name, ROIIndex);
+        Roi o = getROI(ROIIndex);
+        o.setName(toRType(name));
     }
 
     //////// Reagent /////////


### PR DESCRIPTION
Importing an OME-TIFF file that defines an ROI with the ```Name``` attribute set currently results in the name being lost.  This change should make it so that the ROI name is correctly saved during import.

I'd guess this was just an oversight when names were added in https://github.com/ome/openmicroscopy/pull/3362, but if there is a reason why the name can't be passed through then happy to discuss alternatives.

A minimal pyramid OME-TIFF with one named ROI is in ```/uod/idr/scratch/inbox/with-roi.ome.tiff```.  