### PR TITLE
Fix import-as by group owners.

### DIFF
--- a/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -336,7 +336,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
             }
 
             Map<Integer, String> failingChecksums = new HashMap<Integer, String>();
-            final Map<String, String> allGroupsContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
+            Map<String, String> groupContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
             final IQueryPrx iQuery = sf.getQueryService(__current);
             final String hql = "SELECT originalFile.hash FROM FilesetEntry "
                     + "WHERE fileset.id = :id AND originalFile.path || originalFile.name = :usedfile";
@@ -349,11 +349,12 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                 try {
                     RString result;
                     try {
-                        result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
+                        result = (RString) iQuery.projection(hql, params, groupContext).get(0).get(0);
                     } catch (SecurityViolation sv) {
                         /* The permissions context probably locks us to only certain groups. */
                         log.debug("all-groups query for file checksum failed, retrying with current group context", sv);
                         result = (RString) iQuery.projection(hql, params).get(0).get(0);
+                        groupContext = null;
                     }
                     serverHash = result.getValue();
                 } catch (IndexOutOfBoundsException | NullPointerException e) {

--- a/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -351,6 +351,10 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                     try {
                         result = (RString) iQuery.projection(hql, params, groupContext).get(0).get(0);
                     } catch (SecurityViolation sv) {
+                        if (groupContext == null) {
+                            /* No other workaround to try. */
+                            throw sv;
+                        }
                         /* The permissions context probably locks us to only certain groups. */
                         log.debug("all-groups query for file checksum failed, retrying with current group context", sv);
                         result = (RString) iQuery.projection(hql, params).get(0).get(0);

--- a/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -44,6 +44,7 @@ import ome.services.blitz.util.ServiceFactoryAware;
 import ome.services.util.Executor;
 import ome.system.Login;
 import omero.RString;
+import omero.SecurityViolation;
 import omero.ServerError;
 import omero.api.IQueryPrx;
 import omero.api.RawFileStorePrx;
@@ -346,7 +347,14 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                 final String clientHash = hashes.get(i);
                 String serverHash = "";
                 try {
-                    final RString result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
+                    RString result;
+                    try {
+                        result = (RString) iQuery.projection(hql, params, allGroupsContext).get(0).get(0);
+                    } catch (SecurityViolation sv) {
+                        /* The permissions context probably locks us to only certain groups. */
+                        log.debug("all-groups query for file checksum failed, retrying with current group context", sv);
+                        result = (RString) iQuery.projection(hql, params).get(0).get(0);
+                    }
                     serverHash = result.getValue();
                 } catch (IndexOutOfBoundsException | NullPointerException e) {
                     log.error("no server checksum on uploaded file {}", usedFile, e);

--- a/src/main/java/ome/services/blitz/repo/PublicRepositoryI.java
+++ b/src/main/java/ome/services/blitz/repo/PublicRepositoryI.java
@@ -1,9 +1,6 @@
 /*
- * ome.services.blitz.repo.PublicRepositoryI
- *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2017 University of Dundee. All rights reserved.
- *
+ *  Copyright (C) 2006-2020 University of Dundee. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -19,8 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  *------------------------------------------------------------------------------
- *
- *
  */
 
 package ome.services.blitz.repo;
@@ -457,9 +452,8 @@ public class PublicRepositoryI implements _RepositoryOperations, ApplicationCont
                     new Executor.SimpleWork<ome.model.core.OriginalFile>(this, "persistLogFile", id) {
                 @Transactional(readOnly = false)
                 public ome.model.core.OriginalFile doWork(Session session, ServiceFactory sf) {
-                    final ome.model.core.OriginalFile persisted = sf.getUpdateService().saveAndReturnObject(originalFile);
+                    final ome.model.core.OriginalFile persisted = sf.getUpdateService().saveAndReturnObject(originalFile).proxy();
                     getSqlAction().setFileRepo(Collections.singleton(persisted.getId()), repoUuid);
-                    session.refresh(persisted);
                     return persisted;
                 }
             });


### PR DESCRIPTION
This PR corrects the OMERO 5.4.6 regression that fails to permit import for group members by group owners who are not administrators.

Fixes https://github.com/ome/omero-server/issues/63 and can be tested with https://github.com/ome/openmicroscopy/pull/6221.

The adjustment to `persistLogFile`'s return value could be considered a minor breaking change.