### PR TITLE
Bump test dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     testImplementation("jmock:jmock:1.+")
     testImplementation("org.testng:testng:6.14.2")
     testImplementation('nl.javadude.assumeng:assumeng:1.2.4')
-    testImplementation('org.openmicroscopy:omero-common-test:5.5.5')
+    testImplementation('org.openmicroscopy:omero-common-test:5.5.6')
     testImplementation('org.quartz-scheduler:quartz:2.2.1')
 
     api("org.openmicroscopy:omero-server:5.6.0")


### PR DESCRIPTION
The omero-common-test dependency in OMERO.blitz should probably match that of OMERO.server.