### PR TITLE
Fix fileset ID lookup among managed repository processes.

### DIFF
--- a/src/main/java/ome/services/blitz/repo/ManagedRepositoryI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedRepositoryI.java
@@ -312,7 +312,7 @@ public class ManagedRepositoryI extends PublicRepositoryI
         }
 
         for (final ProcessContainer.Process p : ps) {
-            if (filesetIds.contains(p.getFileset().getId())) {
+            if (filesetIds.contains(p.getFileset().getId().getValue())) {
                 proxies.add(p.getProxy());
             }
         }


### PR DESCRIPTION
Reading over the `ManagedRepositoryI.listImports` code this looks to me as if it fixes a clear bug. What its impact is, I don't know.