### PR TITLE
Add support for multiple Ice TLS protocols

### DIFF
--- a/src/main/java/omero/client.java
+++ b/src/main/java/omero/client.java
@@ -379,7 +379,7 @@ public class client {
         optionallySetProperty(id, "Ice.Default.EndpointSelection", "Ordered");
         optionallySetProperty(id, "Ice.Default.PreferSecure", "1");
         optionallySetProperty(id, "Ice.Plugin.IceSSL", "IceSSL.PluginFactory");
-        optionallySetProperty(id, "IceSSL.Protocols", "tls1");
+        optionallySetProperty(id, "IceSSL.Protocols", "tls1_0,tls1_1,tls1_2");
         // This cipher specification includes the default ciphers + anon-DH
         // ciphers required by OMERO.server in its default configuration.
         optionallySetProperty(id, "IceSSL.Ciphers", "(DH_anon.*AES)");


### PR DESCRIPTION
The problem has been fixed on the Python side. See https://github.com/ome/omero-py/pull/251

Travis is still failing on Debian10 when attempting to import an image via the CLI, see https://travis-ci.org/github/ome/omero-install/jobs/727688313
This should fix the issue.

I will use the daily merge build to check if everything works using travis
Daily build used: https://github.com/ome/omero-install/pull/245

cc @mtbc 