### PR TITLE
Fix conversion NPE for PIXELS and REFERENCEFRAME

### DIFF
--- a/src/main/java/omero/model/LengthI.java
+++ b/src/main/java/omero/model/LengthI.java
@@ -944,6 +944,12 @@ public class LengthI extends Length implements ModelBased {
         return Collections.unmodifiableMap(c);
     }
 
+    private static Map<UnitsLength, Conversion> createMapPIXEL() {
+        EnumMap<UnitsLength, Conversion> c =
+                new EnumMap<UnitsLength, Conversion>(UnitsLength.class);
+        return Collections.unmodifiableMap(c);
+    }
+
     private static Map<UnitsLength, Conversion> createMapPOINT() {
         EnumMap<UnitsLength, Conversion> c =
             new EnumMap<UnitsLength, Conversion>(UnitsLength.class);
@@ -978,6 +984,12 @@ public class LengthI extends Length implements ModelBased {
         c.put(UnitsLength.YOTTAMETER, Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 20))), Sym("pt")));
         c.put(UnitsLength.ZEPTOMETER, Mul(Rat(Mul(Int(125), Pow(10, 22)), Int(3543309)), Sym("pt")));
         c.put(UnitsLength.ZETTAMETER, Mul(Rat(Int(1), Mul(Int(28346472), Pow(10, 17))), Sym("pt")));
+        return Collections.unmodifiableMap(c);
+    }
+
+    private static Map<UnitsLength, Conversion> createMapREFERENCEFRAME() {
+        EnumMap<UnitsLength, Conversion> c =
+                new EnumMap<UnitsLength, Conversion>(UnitsLength.class);
         return Collections.unmodifiableMap(c);
     }
 
@@ -1270,7 +1282,9 @@ public class LengthI extends Length implements ModelBased {
         c.put(UnitsLength.PARSEC, createMapPARSEC());
         c.put(UnitsLength.PETAMETER, createMapPETAMETER());
         c.put(UnitsLength.PICOMETER, createMapPICOMETER());
+        c.put(UnitsLength.PIXEL, createMapPIXEL());
         c.put(UnitsLength.POINT, createMapPOINT());
+        c.put(UnitsLength.REFERENCEFRAME, createMapREFERENCEFRAME());
         c.put(UnitsLength.TERAMETER, createMapTERAMETER());
         c.put(UnitsLength.THOU, createMapTHOU());
         c.put(UnitsLength.YARD, createMapYARD());

--- a/src/test/java/omero/model/utests/UnitsTest.java
+++ b/src/test/java/omero/model/utests/UnitsTest.java
@@ -90,4 +90,9 @@ public class UnitsTest {
     public void testLengthMappingFromCentimeterToMeter() throws BigResult {
         new LengthI(mm(1, UnitsLength.CENTIMETER), UnitsLength.METER);
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLengthMappingFromPixelToMicrometer() throws BigResult {
+        new LengthI(mm(1, UnitsLength.PIXEL), UnitsLength.MICROMETER);
+    }
 }

--- a/src/test/java/omero/model/utests/UnitsTest.java
+++ b/src/test/java/omero/model/utests/UnitsTest.java
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package ome.formats.utests;
+package omero.model.utests;
 
 import ome.model.units.BigResult;
 import ome.units.UNITS;

--- a/src/test/java/omero/model/utests/UnitsTest.java
+++ b/src/test/java/omero/model/utests/UnitsTest.java
@@ -95,4 +95,9 @@ public class UnitsTest {
     public void testLengthMappingFromPixelToMicrometer() throws BigResult {
         new LengthI(mm(1, UnitsLength.PIXEL), UnitsLength.MICROMETER);
     }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testLengthMappingFromReferenceFrameToMicrometer() throws BigResult {
+        new LengthI(mm(1, UnitsLength.REFERENCEFRAME), UnitsLength.MICROMETER);
+    }
 }


### PR DESCRIPTION
This PR follows on from #76 based on the investigation from glencoesoftware/omero-ms-image-region#99 ensuring that conversions from PIXELS or REFERENCEFRAME throw the correct exceptions just like conversions to those units. Since these two units are the only examples across the seven (ElectricalPotential, Frequency, Length, Power, Pressure, Temperature, Time) originally modified I made the decision just to set up empty conversion maps rather than modify all the implementations.

The unit tests for the unit infrastructure have also been reactivated as part of this PR.

@dominikl, @jburel: You will definitely want to make sure this does not break things vs. what the Java gateway is doing.
