### PR TITLE
Workflows and dependency upgrade

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,49 +9,26 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        java: [1.8, 11]
-        os: [ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
-    env:
-      gradle_version: 6.8.3 # set to empty to build with most recent version of gradle
-      gradle_commands: build -x javadoc # default is build
-      ICE_HOME: /opt/ice-3.6.5 # location where Ice is installed
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Install slice2java
-        run: |
-          sudo apt-get install -y libmcpp-dev
-          wget -q https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          tar xf ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          mv ice-3.6.5-0.2.0 ice-3.6.5
-          mv ice-3.6.5 /opt
-          rm ice-3.6.5-0.2.0-ubuntu2004-amd64.tar.gz
-          echo "${{ env.ICE_HOME }}/bin" >> $GITHUB_PATH
-      - name: Install slice2py
-        run: |
-          sudo pip install https://github.com/ome/zeroc-ice-ubuntu2004/releases/download/0.2.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl
-          sudo ln -s /usr/local/bin/slice2py /usr/bin/slice2py
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Wrap with specified version
-        run: |
-          gradle wrapper --gradle-version=${{ env.gradle_version }}
-        if: ${{ env.gradle_version != '' }}
-        shell: bash
-      - name: Wrap without version
-        run: |
-          gradle wrapper
-        if: ${{ env.gradle_version == '' }}
-        shell: bash
-      - name: Run commands
-        run: ./gradlew ${{ env.gradle_commands }}
+    uses: ome/action-workflows/.github/workflows/gradle_build.yml@v1.2
+    with:
+      install-ice: true
+  publish_snapshots:
+    if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'ome' }}
+    needs: build
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v1.2
+    with:
+      install-ice: true
+      ARTIFACTORY_URL: "snapshots"
+    secrets:
+      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+  publish:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags') && github.repository_owner == 'ome'
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v1.2
+    with:
+      install-ice: true
+      ARTIFACTORY_URL: "staging"
+    secrets:
+      ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
+      ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testImplementation('org.openmicroscopy:omero-common-test:5.5.9')
     testImplementation('org.quartz-scheduler:quartz:2.2.1')
     
-    api("org.openmicroscopy:omero-server:5.6.3")
+    api("org.openmicroscopy:omero-server:5.6.4")
 
     implementation("com.sun.activation:javax.activation:1.2.0")
     implementation("org.ini4j:ini4j:0.4.1")

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "org.openmicroscopy.api" version "5.5.0"
     id "org.openmicroscopy.dsl" version "5.5.2"
     id "org.openmicroscopy.blitz" version "5.5.2"
-    id "org.openmicroscopy.project" version "5.5.1"
+    id "org.openmicroscopy.project" version "5.5.4"
     id "org.openmicroscopy.gradle.ice-builder.slice" version "1.5.0"
 }
 


### PR DESCRIPTION
- update Gradle workflow to publish SNAPSHOTS and release
- bump org.openmicroscopy.org plugin to consume version 5.5.4
- bump org.openmicroscopy:ome-server to version 5.6.4

