### PR TITLE
Add the python and icedoc artifacts to the omeroBlitz publication

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -11,10 +11,8 @@ task zipIcedoc(type: Zip) {
 
 publishing {
     publications {
-        blitzPython(MavenPublication) {
+        omeroBlitz {
             artifact pythonZip
-        }
-        blitzIcedoc(MavenPublication) {
             artifact zipIcedoc
         }
     }


### PR DESCRIPTION
In terms of deployment, this means all artifacts (Java, Python, Icedoc) should be published in a single transaction. For SNAPSHOT artifacts, this should now avoid the creation of three successive iterations. For release artifacts, this should remove the requirement for a privileged user as the POM should not be overwritten.

