### PR TITLE
Explicitly include details.externalInfo when relinking duplicate objects

### DIFF
--- a/src/main/java/omero/cmd/graphs/DuplicateI.java
+++ b/src/main/java/omero/cmd/graphs/DuplicateI.java
@@ -573,7 +573,7 @@ public class DuplicateI extends Duplicate implements IRequest, ReadOnlyStatus.Is
                         final String linkedClassName = forwardLink.getKey();
                         final String property = forwardLink.getValue();
                         /* ignore details for now, duplicates never preserve original ownership */
-                        if (property.startsWith("details.")) {
+                        if (property.startsWith("details.") && !property.equals("details.externalInfo")) {
                             continue;
                         }
                         /* note which of the objects to which the original links should be ignored */


### PR DESCRIPTION
The current implementation will duplicate objects with ExternalInfo objects associated to them and create both the original object as well as a duplicated ExternalInfo object. However, the linking between the duplicated objects is lost since the externalInfo link is stored under `details.externalInfo`.

This commit should allow to properly handle this scenario and relink the duplicated objects.

/cc @emilroz @muhanadz 

Proposed tag: `5.5.13`