### PR TITLE
Command line importer developer user experience improvements

### DIFF
--- a/src/main/java/ome/formats/importer/ImportConfig.java
+++ b/src/main/java/ome/formats/importer/ImportConfig.java
@@ -656,7 +656,7 @@ public class ImportConfig {
                 username.set(System.console().readLine("Username: "));
             }
             if (password.empty()) {
-                username.set(new String(
+                password.set(new String(
                         System.console().readPassword("Password: ")));
             }
         }

--- a/src/main/java/ome/formats/importer/ImportConfig.java
+++ b/src/main/java/ome/formats/importer/ImportConfig.java
@@ -648,11 +648,17 @@ public class ImportConfig {
      *  if can't log in request needed information
      */
     public void requestFromUser() {
-        if (!canLogin()) {
-            loadAll();
-            prompt(hostname, " Enter server name: ", false);
-            prompt(username, " Enter user name: ", false);
-            prompt(password, " Enter password: ", true);
+        if (hostname.empty()) {
+            hostname.set(System.console().readLine("Hostname: "));
+        }
+        if (sessionKey.empty()) {
+            if (username.empty()) {
+                username.set(System.console().readLine("Username: "));
+            }
+            if (password.empty()) {
+                username.set(new String(
+                        System.console().readPassword("Password: ")));
+            }
         }
     }
 

--- a/src/main/java/ome/formats/importer/ImportLibrary.java
+++ b/src/main/java/ome/formats/importer/ImportLibrary.java
@@ -860,6 +860,14 @@ public class ImportLibrary implements IObservable
     // =========================================================================
 
     /**
+     * Retrieves the currently active metadata store.
+     * @return See above.
+     */
+    public OMEROMetadataStoreClient getMetadataStore() {
+        return store;
+    }
+
+    /**
      * Retrieves the first managed repository from the list of current active
      * repositories.
      * @return Active proxy for the legacy repository.

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -156,8 +156,7 @@ public class CommandLineImporter {
 
             // Ensure that we have all of our required login arguments
             if (!config.canLogin()) {
-                // config.requestFromUser(); // stdin if anything missing.
-                usage(); // EXITS TODO this should check for a "quiet" flag
+                config.requestFromUser(); // stdin if anything missing.
             }
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -156,7 +156,8 @@ public class CommandLineImporter {
 
             // Ensure that we have all of our required login arguments
             if (!config.canLogin()) {
-                config.requestFromUser(); // stdin if anything missing.
+                // config.requestFromUser(); // stdin if anything missing.
+                usage(); // EXITS TODO this should check for a "quiet" flag
             }
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -154,11 +154,7 @@ public class CommandLineImporter {
 
         } else {
 
-            // Ensure that we have all of our required login arguments
-            if (!config.canLogin()) {
-                // config.requestFromUser(); // stdin if anything missing.
-                usage(); // EXITS TODO this should check for a "quiet" flag
-            }
+            checkLogin();
             store = config.createStore();
             store.logVersionInfo(config.getIniVersionNumber());
             reader.setMetadataOptions(
@@ -179,6 +175,18 @@ public class CommandLineImporter {
                 cleanup();
             }
         });
+    }
+
+    /**
+     * Checks that requisite command line options for OMERO session
+     * creation have been provided and if not calls
+     * {@link CommandLineImporter#usage()}.
+     */
+    protected void checkLogin() {
+        // Ensure that we have all of our required login arguments
+        if (!config.canLogin()) {
+            usage(); // EXITS TODO this should check for a "quiet" flag
+        }
     }
 
     /**

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -79,19 +79,19 @@ public class CommandLineImporter {
     public final ErrorHandler handler;
 
     /** Bio-Formats reader wrapper customized for OMERO. */
-    private final OMEROWrapper reader;
+    protected final OMEROWrapper reader;
 
     /** Bio-Formats {@link MetadataStore} implementation for OMERO. */
-    private final OMEROMetadataStoreClient store;
+    protected final OMEROMetadataStoreClient store;
 
     /** Candidates for import */
-    private final ImportCandidates candidates;
+    protected final ImportCandidates candidates;
 
     /** If true, then only a report on used files will be produced */
-    private final boolean getUsedFiles;
+    protected final boolean getUsedFiles;
 
     /** Format which should be preferred for standard out messages */
-    private ImportOutput importOutput = ImportOutput.ids;
+    protected ImportOutput importOutput = ImportOutput.ids;
 
     /**
      * Legacy constructor which uses a {@link UploadFileTransfer}.

--- a/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
+++ b/src/main/java/ome/formats/importer/cli/CommandLineImporter.java
@@ -163,7 +163,7 @@ public class CommandLineImporter {
             reader.setMetadataOptions(
                     new DynamicMetadataOptions(MetadataLevel.ALL));
 
-            library = new ImportLibrary(store, reader,
+            library = createImportLibrary(store, reader,
                     transfer, exclusions, minutesToWait);
 
             if (config.checkUpgrade.get()) {
@@ -178,6 +178,22 @@ public class CommandLineImporter {
                 cleanup();
             }
         });
+    }
+
+    /**
+     * Creates the {@link ImportLibrary} that this command line importer will
+     * use to import data
+     * @param client Bio-Formats {@link MetadataStore} implementation for OMERO
+     * @param reader Bio-Formats reader wrapper customized for OMERO
+     * @param transfer {@link FileTransfer} mechanism to be used for uploading
+     * @param exclusions {@link FileExclusion} mechanisms for skipping candidates
+     * @param minutesToWait for how many minutes to wait for an import (negative for indefinitely)
+     * @return See above.
+     */
+    protected ImportLibrary createImportLibrary(
+            OMEROMetadataStoreClient client, OMEROWrapper reader, FileTransfer transfer,
+            List<FileExclusion> exclusions, int minutesToWait) {
+        return new ImportLibrary(store, reader, transfer, exclusions, minutesToWait);
     }
 
     /**

--- a/src/main/java/ome/formats/importer/cli/ImportCloser.java
+++ b/src/main/java/ome/formats/importer/cli/ImportCloser.java
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  * Stateful class for use by {@link CommandLineImporter} to interact
  * with server-side processes which are running.
  */
-class ImportCloser {
+public class ImportCloser {
 
     private final static Logger log = LoggerFactory.getLogger(ImportCloser.class);
 

--- a/src/main/java/ome/formats/importer/cli/ImportOutput.java
+++ b/src/main/java/ome/formats/importer/cli/ImportOutput.java
@@ -23,7 +23,7 @@ package ome.formats.importer.cli;
 /**
  * Styles of output which are supported by the {@link CommandLineImporter}.
  */
-enum ImportOutput {
+public enum ImportOutput {
 
     ids,
     legacy,


### PR DESCRIPTION
A few developer user experience improvements for those who may want to subclass `CommandLineImporter` for their own purposes and change various behaviour. Most of the changes are just adjusting visibility in line with this aim. The only exception is the restoration of the broken credential retrieval logic if all the `omero.client` pre-requisites are not provided on the command line; there should be no end user behavioural changes exposed other than this.

/cc @kkoz, @sbesson 