### PR TITLE
Fix javadoc warning

### DIFF
--- a/src/main/slice/omero/api/ThumbnailStore.ice
+++ b/src/main/slice/omero/api/ThumbnailStore.ice
@@ -389,7 +389,7 @@ module omero {
                  *             <ul>
                  *             <li><code>sizeX</code> is negative</li>
                  *             <li><code>sizeY</code> is negative</li>
-                 *             <li>{@link setPixelsId} has not yet been called</li>
+                 *             <li>{@code setPixelsId} has not yet been called</li>
                  *             </ul>
                  * @see #getThumbnail
                  * @see #getThumbnailDirect


### PR DESCRIPTION
The change matches the existing format
This should fix
```
> Task :omero-blitz:javadoc
/home/omero/workspace/OMERO-build-build/omero-blitz/build/psql/ice36/omero/api/_ThumbnailStoreDisp.java:555: warning - Tag @link: reference not found: #setPixelsId
/home/omero/workspace/OMERO-build-build/omero-blitz/build/psql/ice36/omero/api/_ThumbnailStoreOperations.java:402: warning - Tag @link: reference not found: #setPixelsId
/home/omero/workspace/OMERO-build-build/omero-blitz/build/psql/ice36/omero/api/_ThumbnailStoreOperationsNC.java:386: warning - Tag @link: reference not found: #setPixelsId
```