### PR TITLE
Declare logback-classic as explicit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpmime:4.5.6")
     implementation("gnu.getopt:java-getopt:1.0.13")
     implementation("net.sf.ehcache:ehcache:2.10.6")
+    implementation("ch.qos.logback:logback-classic:1.3.4")
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpmime:4.5.6")
     implementation("gnu.getopt:java-getopt:1.0.13")
     implementation("net.sf.ehcache:ehcache:2.10.6")
-    implementation("ch.qos.logback:logback-classic:1.3.4")
+    implementation("ch.qos.logback:logback-classic:1.3.5")
 }
 
 configurations.all {


### PR DESCRIPTION
The work on the upstream ome-* components to declare logback as optional dependencies (following the SLF4J best practice recommendations) has exposed the fact that omero-blitz and specifically ManagedImportRequestI currently has a direct dependency on this logging implementation.

See https://github.com/ome/ome-metakit/pull/11#issuecomment-1386743130