### PR TITLE
bump to action-workflows 2.1

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     needs: build
     if: startsWith(github.ref, 'refs/tags') && github.repository_owner == 'ome'
-    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v2
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v2.1
     with:
       install-ice: true
       ARTIFACTORY_URL: "releases"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   build:
-    uses: ome/action-workflows/.github/workflows/gradle_build.yml@v2
+    uses: ome/action-workflows/.github/workflows/gradle_build.yml@v2.1
     with:
       install-ice: true
   publish_snapshots:
     if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'ome' }}
     needs: build
-    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v2
+    uses: ome/action-workflows/.github/workflows/gradle_publish.yml@v2.1
     with:
       install-ice: true
       ARTIFACTORY_URL: "snapshots"


### PR DESCRIPTION
Bump to v2.1 to avoid warning when installing ice and Python