### PR TITLE
Set logback dependency to 1.2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation("gnu.getopt:java-getopt:1.0.13")
     implementation("net.sf.ehcache:ehcache:2.10.6")
     implementation("ch.qos.logback:logback-classic:1.2.11")
+    // Use the same slfj4-api version as declared in Bio-Formats
+    implementation("org.slf4j:slf4j-api:1.7.30")
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpmime:4.5.6")
     implementation("gnu.getopt:java-getopt:1.0.13")
     implementation("net.sf.ehcache:ehcache:2.10.6")
-    implementation("ch.qos.logback:logback-classic:1.3.5")
+    implementation("ch.qos.logback:logback-classic:1.2.11")
 }
 
 configurations.all {


### PR DESCRIPTION
Bio-Formats 6.12.x which is a transitive dependency of this component ships slf4-api 1.7.x which is only supported up to 1.2.x While using logback 1.3.x is doable and Gradle will automatically select a higher version of slj4-api 2.x, this might cause problems for downstream components using different resolution mechanisms like Ivy or Maven

Hopefully this is the solution for the build failures of https://github.com/ome/openmicroscopy/pull/6341