### PR TITLE
Revert "Java client init: no "anon" among jdk.tls.disabledAlgorithms"

### DIFF
--- a/src/main/java/omero/client.java
+++ b/src/main/java/omero/client.java
@@ -29,7 +29,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -199,42 +198,6 @@ public class client {
 
     // Creation
     // =========================================================================
-
-    /**
-     * Ensure that anonymous cipher suites are enabled in the JRE.
-     */
-    static {
-        final String property = "jdk.tls.disabledAlgorithms";
-        final String value = Security.getProperty(property);
-        if (!(value == null || value.trim().isEmpty())) {
-            final List<String> algorithms = new ArrayList<>();
-            boolean isChanged = false;
-            for (String algorithm : value.split(",")) {
-                algorithm = algorithm.trim();
-                final String algorithmLower = algorithm.toLowerCase();
-                if (algorithm.isEmpty()) {
-                    /* ignore */
-                } else if (algorithmLower.equals("anon") || algorithmLower.endsWith("_anon")) {
-                    isChanged = true;
-                } else {
-                    algorithms.add(algorithm);
-                }
-            }
-            if (isChanged) {
-                boolean needsComma = false;
-                final StringBuilder newValue = new StringBuilder();
-                for (final String algorithm : algorithms) {
-                    if (needsComma) {
-                        newValue.append(", ");
-                    } else {
-                        needsComma = true;
-                    }
-                    newValue.append(algorithm);
-                }
-                Security.setProperty(property, newValue.toString());
-            }
-        }
-    }
 
     private static Properties defaultRouter(String host, int port) {
         Properties p = new Properties();


### PR DESCRIPTION
This reverts commit a9a5a85afe0a8ec4f5867000fc65a46c609bf0ae. See https://github.com/ome/omero-blitz/pull/139#issuecomment-1628709004

We are now enforcing certificates to be set-up server-side and anonymous ciphers have been removed from the client initialisation code (in Java and Python). The current workaround of updating `jdk.tls.disabledAlgorithms` is no longer a requirement.

This commit has been tested cross-platform matrix using the same process as https://github.com/ome/omero-certificates/pull/36#pullrequestreview-1582357647 with no regression found. Opening for inclusion in the nightly CI builds and potential integration in an upcoming omero-blitz release