### PR TITLE
Improve checksum validation performance for large filesets

### DIFF
--- a/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -343,6 +343,7 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                     + "WHERE fileset.id = :id";
             final Parameters params = new ParametersI().addId(fs.getId());
             List<List<RType>> results;
+            StopWatch sw1 = new Slf4JStopWatch();
             try {
                 results = iQuery.projection(hql, params, groupContext);
             } catch (SecurityViolation sv) {
@@ -362,7 +363,6 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                     ((RString) results.get(i).get(0)).getValue());
             }
             for (int i = 0; i < size; i++) {
-                StopWatch sw1 = new Slf4JStopWatch();
                 String usedFile = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
                 final String clientHash = hashes.get(i);
                 String serverHash = serverHashes.getOrDefault(usedFile, null);
@@ -372,9 +372,8 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
                 } else if (!clientHash.equals(serverHash)) {
                     failingChecksums.put(i, serverHash);
                 }
-
-                sw1.stop("omero.import.process.checksum");
             }
+            sw1.stop("omero.import.process.checksum");
 
             if (!failingChecksums.isEmpty()) {
                 throw new omero.ChecksumValidationException(null,

--- a/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
+++ b/src/main/java/ome/services/blitz/repo/ManagedImportProcessI.java
@@ -44,6 +44,7 @@ import ome.services.blitz.util.ServiceFactoryAware;
 import ome.services.util.Executor;
 import ome.system.Login;
 import omero.RString;
+import omero.RType;
 import omero.SecurityViolation;
 import omero.ServerError;
 import omero.api.IQueryPrx;
@@ -338,35 +339,40 @@ public class ManagedImportProcessI extends AbstractCloseableAmdServant
             Map<Integer, String> failingChecksums = new HashMap<Integer, String>();
             Map<String, String> groupContext = ImmutableMap.of(Login.OMERO_GROUP, "-1");
             final IQueryPrx iQuery = sf.getQueryService(__current);
-            final String hql = "SELECT originalFile.hash FROM FilesetEntry "
-                    + "WHERE fileset.id = :id AND originalFile.path || originalFile.name = :usedfile";
+            final String hql = "SELECT originalFile.hash, originalFile.path || originalFile.name FROM FilesetEntry "
+                    + "WHERE fileset.id = :id";
+            final Parameters params = new ParametersI().addId(fs.getId());
+            List<List<RType>> results;
+            try {
+                results = iQuery.projection(hql, params, groupContext);
+            } catch (SecurityViolation sv) {
+                if (groupContext == null) {
+                    /* No other workaround to try. */
+                    throw sv;
+                }
+                /* The permissions context probably locks us to only certain groups. */
+                log.debug("all-groups query for file checksum failed, retrying with current group context", sv);
+                results = iQuery.projection(hql, params);
+                groupContext = null;
+            }
+            Map<String, String> serverHashes = new HashMap<String, String>();
+            for (int i = 0; i < results.size(); i++) {
+                serverHashes.put(
+                    ((RString) results.get(i).get(1)).getValue(),
+                    ((RString) results.get(i).get(0)).getValue());
+            }
             for (int i = 0; i < size; i++) {
                 StopWatch sw1 = new Slf4JStopWatch();
                 String usedFile = location.sharedPath + FsFile.separatorChar + location.usedFiles.get(i);
-                final Parameters params = new ParametersI().addId(fs.getId()).add("usedfile", omero.rtypes.rstring(usedFile));
                 final String clientHash = hashes.get(i);
-                String serverHash = "";
-                try {
-                    RString result;
-                    try {
-                        result = (RString) iQuery.projection(hql, params, groupContext).get(0).get(0);
-                    } catch (SecurityViolation sv) {
-                        if (groupContext == null) {
-                            /* No other workaround to try. */
-                            throw sv;
-                        }
-                        /* The permissions context probably locks us to only certain groups. */
-                        log.debug("all-groups query for file checksum failed, retrying with current group context", sv);
-                        result = (RString) iQuery.projection(hql, params).get(0).get(0);
-                        groupContext = null;
-                    }
-                    serverHash = result.getValue();
-                } catch (IndexOutOfBoundsException | NullPointerException e) {
-                    log.error("no server checksum on uploaded file {}", usedFile, e);
-                }
-                if (serverHash.isEmpty() || !clientHash.equals(serverHash)) {
+                String serverHash = serverHashes.getOrDefault(usedFile, null);
+                if (serverHash == null) {
+                    log.error("no server checksum on uploaded file {}", usedFile);
+                    failingChecksums.put(i, "");
+                } else if (!clientHash.equals(serverHash)) {
                     failingChecksums.put(i, serverHash);
                 }
+
                 sw1.stop("omero.import.process.checksum");
             }
 


### PR DESCRIPTION
Fixes #73 

The currently implementation of the checksum validation in `ManagedImportProcessI.verifyUpload()` retrieves the server hashes by executing as many HQL queries as the number of OriginalFile objects in the fileset.
For filesets containing 1K-100K files which is fairly common in the high-content screening domains and individual queries taking ~100-200ms, this can lead to multiple hours of checksum verification.
    
This commit updates the logic to use a single HQL query and create a hash map of all serverHashes for the fileset indexed by their originalfile path/name. This map is then used in the following loop to compare each hash to the client checksum.

The stopwatch is also updated to measure the overall time of the checksum validation process as the individual server/client comparisons in the loop should now take under 1ms.

HCS acquisitions containing 1-10K files are good candidates for testing this change. Example of public representative plates can be found under [idr0006](https://downloads.openmicroscopy.org/images/MetaXpress/idr0006), [BBBC017](https://downloads.openmicroscopy.org/images/Cellomics/BBBC017/).

Client-side, the checksum verification time corresponds to the time between the last `FILE_UPLOAD_COMPLETE:` statement and the `FILESET_UPLOAD_END` statement in the command-line importer logs. Post-import, the overall upload time can also be retrieved post import using `omero fs importtime Fileset:<id>`.

Without this PR, the validation time will increase linearly with the number of files and be in the order of hours for very large filesets. With this PR, this process should take typically less than a second.
