### PR TITLE
OMEROMetadataStoreClient: fall back to secure session on SocketException

### DIFF
--- a/src/main/java/ome/formats/OMEROMetadataStoreClient.java
+++ b/src/main/java/ome/formats/OMEROMetadataStoreClient.java
@@ -768,9 +768,9 @@ public class OMEROMetadataStoreClient
             try
             {
                 unsecure();
-            } catch (Ice.ConnectionRefusedException cre)
+            } catch (Ice.SocketException se)
             {
-                log.warn("Cannot fallback. Using secure connection", cre);
+                log.warn("Cannot fallback. Using secure connection", se);
             }
         }
 


### PR DESCRIPTION
Following authentication using the 4064 port (SSL), the importer will attempt to create an unsecure client using TCP port 4063. Currently if this session creation results in an `Ice.ConnectionRefusedException` exception e.g. because port 4063 is blocked, it will fall back to the secure client and continue the import.

Under some conditions that might depend both on the operating system and Java, `unsecure()` might throw an
`Ice.SocketException: java.net.NoRouteToHostException: No route to host` which currently aborts the import.

This commit proposes to relax the exception handling to catch any `Ice.SocketException` (see https://doc.zeroc.com/ice/3.6/the-slice-language/interfaces-operations-and-exceptions/run-time-exceptions for the graph of Ice exceptions) and fallback to a secure connection.

Testing this can be tricky as I have not identified an environment allowing to reproduce the original issue. For reference, the original stack trace was

```
2025-05-08 15:36:55,239 367        [      main] INFO          ome.formats.importer.ImportConfig - OMERO.blitz Version: 5.8.0
2025-05-08 15:36:55,267 395        [      main] INFO          ome.formats.importer.ImportConfig - Bioformats version: 8.0.1 revision: b04aff540bacd9db3d58bd9c90a7464d8c7328d5 date: 14 November 2024
2025-05-08 15:36:55,332 460        [      main] INFO   formats.importer.cli.CommandLineImporter - Log levels -- Bio-Formats: ERROR OMERO.importer: INFO
2025-05-08 15:36:55,752 880        [      main] INFO      ome.formats.importer.ImportCandidates - Depth: 4 Metadata Level: MINIMUM
...
2025-05-08 15:36:56,833 1961       [      main] INFO       ome.formats.OMEROMetadataStoreClient - Insecure connection requested, falling back
2025-05-08 15:36:56,969 2097       [      main] ERROR  formats.importer.cli.CommandLineImporter - Error during import process.
Ice.SocketException: java.net.NoRouteToHostException: No route to host
      at IceInternal.AsyncResultI.__wait([AsyncResultI.java:276](http://asyncresulti.java:276/))
      at Ice.ObjectPrxHelperBase.end_ice_isA([ObjectPrxHelperBase.java:310](http://objectprxhelperbase.java:310/))
      at Ice.ObjectPrxHelperBase.ice_isA([ObjectPrxHelperBase.java:92](http://objectprxhelperbase.java:92/))
      at Ice.ObjectPrxHelperBase.ice_isA([ObjectPrxHelperBase.java:69](http://objectprxhelperbase.java:69/))
      at Ice.ObjectPrxHelperBase.checkedCastImpl([ObjectPrxHelperBase.java:2810](http://objectprxhelperbase.java:2810/))
      at Ice.ObjectPrxHelperBase.checkedCastImpl([ObjectPrxHelperBase.java:2770](http://objectprxhelperbase.java:2770/))
      at Glacier2.RouterPrxHelper.checkedCast([RouterPrxHelper.java:1787](http://routerprxhelper.java:1787/))
      at omero.client.getRouter([client.java:848](http://client.java:848/))
      at omero.client.createSession([client.java:769](http://client.java:769/))
      at omero.client.joinSession([client.java:704](http://client.java:704/))
      at omero.client.createClient([client.java:503](http://client.java:503/))
      at ome.formats.OMEROMetadataStoreClient.unsecure([OMEROMetadataStoreClient.java:810](http://omerometadatastoreclient.java:810/))
      at ome.formats.OMEROMetadataStoreClient.initialize([OMEROMetadataStoreClient.java:770](http://omerometadatastoreclient.java:770/))
      at ome.formats.importer.ImportConfig.createStore([ImportConfig.java:381](http://importconfig.java:381/))
      at ome.formats.importer.cli.CommandLineImporter.<init>([CommandLineImporter.java:158](http://commandlineimporter.java:158/))
      at ome.formats.importer.cli.CommandLineImporter.main([CommandLineImporter.java:1021](http://commandlineimporter.java:1021/))
Caused by: java.net.NoRouteToHostException: No route to host
      at java.base/sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
      at java.base/sun.nio.ch.SocketChannelImpl.finishConnect([SocketChannelImpl.java:779](http://socketchannelimpl.java:779/))
      at IceInternal.Network.doFinishConnect([Network.java:437](http://network.java:437/))
      at IceInternal.StreamSocket.connect([StreamSocket.java:96](http://streamsocket.java:96/))
      at IceInternal.TcpTransceiver.initialize([TcpTransceiver.java:24](http://tcptransceiver.java:24/))
      at Ice.ConnectionI.initialize([ConnectionI.java:1921](http://connectioni.java:1921/))
      at Ice.ConnectionI.message([ConnectionI.java:940](http://connectioni.java:940/))
      at [IceInternal.ThreadPool.run](http://iceinternal.threadpool.run/)([ThreadPool.java:395](http://threadpool.java:395/))
      at IceInternal.ThreadPool.access$300([ThreadPool.java:12](http://threadpool.java:12/))
      at [IceInternal.ThreadPool$EventHandlerThread.run](http://iceinternal.threadpool$eventhandlerthread.run/)([ThreadPool.java:832](http://threadpool.java:832/))
      at java.base/java.lang.Thread.run([Thread.java:834](http://thread.java:834/))
```

At minimum, functional testing should ensure that this change causes no regression when importing against an OMERO.server with port 4063 blocked (e.g. via `iptables`) and the importer should be able to fall back to the secure session for uploading the files.