### PR TITLE
Bump logback-classic from 1.3.15 to 1.3.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation("org.apache.httpcomponents:httpmime:4.5.6")
     implementation("gnu.getopt:java-getopt:1.0.13")
     implementation("net.sf.ehcache:ehcache:2.10.9.2")
-    implementation("ch.qos.logback:logback-classic:1.3.15")
+    implementation("ch.qos.logback:logback-classic:1.3.16")
 }
 
 configurations.all {


### PR DESCRIPTION
See https://logback.qos.ch/news.html#1.3.16 for the list of changes

This mirrors the bump in the lower level components - see https://github.com/ome/ome-common-java/pull/106, https://github.com/ome/bioformats/pull/4383 amongst others 