### PR TITLE
Update link creation for use Java API instead of `ln` or `mklink` commands

### DIFF
--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -159,6 +159,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      */
     protected void exec(File file, File location) throws IOException {
         ProcessBuilder pb = createProcessBuilder(file, location);
+        if (pb == null) {
+            return;
+        }
         pb.redirectErrorStream(true);
         Process process = pb.start();
         Integer rcode = null;

--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -152,12 +152,55 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
 
     /**
      * Executes a local command and fails on non-0 return codes.
+     * This method should be overridden by subclasses, see for example
+     * {@link CopyFileTransfer}.
      *
      * @param file the source file
      * @param location the target on the server
      * @throws IOException for problems with the source file
      */
-    protected abstract void exec(File file, File location) throws IOException;
+    protected void exec(File file, File location) throws IOException {
+        ProcessBuilder pb = createProcessBuilder(file, location);
+        if (pb == null) {
+            return;
+        }
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        Integer rcode = null;
+        while (rcode == null) {
+            try {
+                rcode = process.waitFor();
+                break;
+            } catch (InterruptedException e) {
+                continue;
+            }
+        }
+        if (rcode == null || rcode.intValue() != 0) {
+            StringWriter sw = new StringWriter();
+            sw.append("transfer process returned: ");
+            sw.append(Integer.toString(rcode));
+            sw.append("\n");
+            sw.append("command:");
+            for (String arg : pb.command()) {
+                sw.append(" ");
+                sw.append(arg);
+            }
+            sw.append("\n");
+            sw.append("output:");
+            sw.append(LINE);
+            String line = "";
+            BufferedReader br = new BufferedReader(
+                   new InputStreamReader(process.getInputStream()));
+            while ( (line = br.readLine()) != null) {
+               sw.append(line);
+               sw.append(SEPARATOR);
+            }
+            sw.append(LINE);
+            String msg = sw.toString();
+            log.error(msg);
+            throw new RuntimeException(msg);
+        }
+    }
 
     /**
      * Check that the server can properly read the copied file.

--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -205,7 +205,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      * @deprecated override {@link #exec(File, File)} instead
      */
     @Deprecated
-    protected abstract ProcessBuilder createProcessBuilder(File file, File location);
+    protected ProcessBuilder createProcessBuilder(File file, File location) {
+        return null;
+    }
 
     protected void printLine() {
         log.error("*******************************************");

--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -157,48 +157,7 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      * @param location the target on the server
      * @throws IOException for problems with the source file
      */
-    protected void exec(File file, File location) throws IOException {
-        ProcessBuilder pb = createProcessBuilder(file, location);
-        if (pb == null) {
-            return;
-        }
-        pb.redirectErrorStream(true);
-        Process process = pb.start();
-        Integer rcode = null;
-        while (rcode == null) {
-            try {
-                rcode = process.waitFor();
-                break;
-            } catch (InterruptedException e) {
-                continue;
-            }
-        }
-        if (rcode == null || rcode.intValue() != 0) {
-            StringWriter sw = new StringWriter();
-            sw.append("transfer process returned: ");
-            sw.append(Integer.toString(rcode));
-            sw.append("\n");
-            sw.append("command:");
-            for (String arg : pb.command()) {
-                sw.append(" ");
-                sw.append(arg);
-            }
-            sw.append("\n");
-            sw.append("output:");
-            sw.append(LINE);
-            String line = "";
-            BufferedReader br = new BufferedReader(
-                   new InputStreamReader(process.getInputStream()));
-            while ( (line = br.readLine()) != null) {
-               sw.append(line);
-               sw.append(SEPARATOR);
-            }
-            sw.append(LINE);
-            String msg = sw.toString();
-            log.error(msg);
-            throw new RuntimeException(msg);
-        }
-    }
+    protected abstract void exec(File file, File location) throws IOException;
 
     /**
      * Check that the server can properly read the copied file.
@@ -243,7 +202,9 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
      * @param file File to be copied.
      * @param location Location to copy to.
      * @return an instance ready for performing the transfer
+     * @deprecated override {@link #exec(File, File)} instead
      */
+    @Deprecated
     protected abstract ProcessBuilder createProcessBuilder(File file, File location);
 
     protected void printLine() {

--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -209,8 +209,4 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
         return null;
     }
 
-    protected void printLine() {
-        log.error("*******************************************");
-    }
-
 }

--- a/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/AbstractExecFileTransfer.java
@@ -34,8 +34,7 @@ import omero.api.RawFileStorePrx;
 import omero.model.OriginalFile;
 
 /**
- * Local-only file transfer mechanism which makes use of soft-linking.
- * This is only useful where the command "ln -s source target" will work.
+ * Abstract base class for file transfer implementations that link or copy files.
  *
  * @since 5.0
  */
@@ -46,9 +45,7 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     private static final String SEPARATOR = System.getProperty("line.separator");
 
     /**
-     * "Transfer" files by soft-linking them into place. This method is likely
-     * re-usable for other general "linking" strategies by overriding
-     * {@link #createProcessBuilder(File, File)} and the other protected methods here.
+     * Transfer files as specified by the {@link #exec(File, File)} implementation.
      */
     public String transfer(TransferState state) throws IOException, ServerError {
         RawFileStorePrx rawFileStore = start(state);
@@ -151,7 +148,12 @@ public abstract class AbstractExecFileTransfer extends AbstractFileTransfer {
     }
 
     /**
-     * Executes a local command and fails on non-0 return codes.
+     * If {@link createProcessBuilder(File, File)} returns non-null,
+     * executes a local command corresponding to the ProcessBuilder
+     * and fails on non-0 return codes.
+     *
+     * If the ProcessBuilder is null, this method does nothing by default.
+     *
      * This method should be overridden by subclasses, see for example
      * {@link CopyFileTransfer}.
      *

--- a/src/main/java/ome/formats/importer/transfers/CopyFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/CopyFileTransfer.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/ome/formats/importer/transfers/CopyFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/CopyFileTransfer.java
@@ -21,44 +21,27 @@ package ome.formats.importer.transfers;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Local-only file transfer mechanism which makes use of the plaform
- * copy command.
- *
- * This is only useful where the commands "cp source target" (Unix) or
- * "copy source target" (Windows) will work.
+ * Local-only file transfer mechanism.
  *
  * @since 5.0.7
  */
 public class CopyFileTransfer extends AbstractExecFileTransfer {
 
     /**
-     * Executes "cp file location" (Unix) or "cp file location" (Windows)
-     * and fails on non-0 return codes.
+     * Copies a file from one location to another.
      *
      * @param file File to be copied
      * @param location Location to copy to.
      * @throws IOException
      */
-    protected ProcessBuilder createProcessBuilder(File file, File location) {
-        ProcessBuilder pb = new ProcessBuilder();
-        List<String> args = new ArrayList<String>();
-        if (isWindows()) {
-            args.add("cmd");
-            args.add("/c");
-            args.add("cp");
-            args.add(file.getAbsolutePath());
-            args.add(location.getAbsolutePath());
-        } else {
-            args.add("cp");
-            args.add(file.getAbsolutePath());
-            args.add(location.getAbsolutePath());
-        }
-        pb.command(args);
-        return pb;
+    protected void exec(File file, File location) throws IOException {
+        Files.copy(Paths.get(file.getAbsolutePath()), Paths.get(location.getAbsolutePath()));
     }
 
     /**

--- a/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
@@ -34,19 +34,14 @@ import java.util.List;
 public class HardlinkFileTransfer extends AbstractExecFileTransfer {
 
     /**
-     * Creates a hard link; returns null.
+     * Creates a hard link.
      *
      * @param file File to be copied.
      * @param location Location to copy to.
-     * @return null
+     * @throws IOException
      */
-    protected ProcessBuilder createProcessBuilder(File file, File location) {
-        try {
-            Files.createLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
-        }
-        catch (IOException e) {
-        }
-        return null;
+    protected void exec(File file, File location) throws IOException {
+        Files.createLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
     }
 
     /**

--- a/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
@@ -21,6 +21,8 @@ package ome.formats.importer.transfers;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/HardlinkFileTransfer.java
@@ -27,40 +27,24 @@ import java.util.List;
 /**
  * Local-only file transfer mechanism which makes use of hard-linking.
  *
- * This is only useful where the commands "ln source target" (Unix) or
- * "mklink /H target source" (Windows) will work.
- *
  * @since 5.0
  */
 public class HardlinkFileTransfer extends AbstractExecFileTransfer {
 
     /**
-     * Executes "ln file location" (Unix) or "mklink /H location file" (Windows)
-     * and fails on non-0 return codes.
+     * Creates a hard link; returns null.
      *
      * @param file File to be copied.
      * @param location Location to copy to.
-     * @throws IOException
-     *
+     * @return null
      */
-    // TODO Java7: replace ln once Java6 is dropped
     protected ProcessBuilder createProcessBuilder(File file, File location) {
-        ProcessBuilder pb = new ProcessBuilder();
-        List<String> args = new ArrayList<String>();
-        if (isWindows()) {
-            args.add("cmd");
-            args.add("/c");
-            args.add("mklink");
-            args.add("/H");
-            args.add(location.getAbsolutePath());
-            args.add(file.getAbsolutePath());
-        } else {
-            args.add("ln");
-            args.add(file.getAbsolutePath());
-            args.add(location.getAbsolutePath());
+        try {
+            Files.createLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
         }
-        pb.command(args);
-        return pb;
+        catch (IOException e) {
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -37,7 +37,7 @@ public class SymlinkFileTransfer extends AbstractExecFileTransfer {
      *
      * @param file File to be copied.
      * @param location Location to copy to.
-     * @param throws IOException
+     * @throws IOException
      */
     protected void exec(File file, File location) throws IOException {
         Files.createSymbolicLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));

--- a/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -21,45 +21,32 @@ package ome.formats.importer.transfers;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Local-only file transfer mechanism which makes use of soft-linking.
  *
- *  This is only useful where the commands "ln -s source target" (Unix) or
- * "mklink target source" (Windows) will work.
- *
  * @since 5.0
  */
 public class SymlinkFileTransfer extends AbstractExecFileTransfer {
 
     /**
-     * Executes "ln -s file location" (Unix) or "mklink location file" (Windows)
-     * and fails on non-0 return codes.
+     * Creates a symlink, returns null.
      *
      * @param file File to be copied.
      * @param location Location to copy to.
-     * @throws IOException
+     * @return null
      */
-    // TODO Java7: replace ln once Java6 is dropped
     protected ProcessBuilder createProcessBuilder(File file, File location) {
-        ProcessBuilder pb = new ProcessBuilder();
-        List<String> args = new ArrayList<String>();
-        if (isWindows()) {
-            args.add("cmd");
-            args.add("/c");
-            args.add("mklink");
-            args.add(location.getAbsolutePath());
-            args.add(file.getAbsolutePath());
-        } else {
-            args.add("ln");
-            args.add("-s");
-            args.add(file.getAbsolutePath());
-            args.add(location.getAbsolutePath());
+        try {
+            Files.createSymbolicLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
         }
-        pb.command(args);
-        return pb;
+        catch (IOException e) {
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
+++ b/src/main/java/ome/formats/importer/transfers/SymlinkFileTransfer.java
@@ -34,19 +34,14 @@ import java.util.List;
 public class SymlinkFileTransfer extends AbstractExecFileTransfer {
 
     /**
-     * Creates a symlink, returns null.
+     * Creates a symlink.
      *
      * @param file File to be copied.
      * @param location Location to copy to.
-     * @return null
+     * @param throws IOException
      */
-    protected ProcessBuilder createProcessBuilder(File file, File location) {
-        try {
-            Files.createSymbolicLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
-        }
-        catch (IOException e) {
-        }
-        return null;
+    protected void exec(File file, File location) throws IOException {
+        Files.createSymbolicLink(Paths.get(location.getAbsolutePath()), Paths.get(file.getAbsolutePath()));
     }
 
     /**


### PR DESCRIPTION
Imports with `--transfer=ln` or `--transfer=ln_s` may be a bit faster, but otherwise this should have no functional impact.